### PR TITLE
Enable manual bike control

### DIFF
--- a/Config/DefaultInput.ini
+++ b/Config/DefaultInput.ini
@@ -25,6 +25,12 @@
 +AxisMappings=(AxisName="Turn",Scale=-1.000000,Key=LeftArrow)
 +AxisMappings=(AxisName="Turn",Scale=1.000000,Key=Gamepad_LeftStick_Right)
 +AxisMappings=(AxisName="Turn",Scale=-1.000000,Key=Gamepad_LeftStick_Left)
++AxisMappings=(AxisName="Throttle",Scale=1.000000,Key=W)
++AxisMappings=(AxisName="Throttle",Scale=-1.000000,Key=S)
++AxisMappings=(AxisName="Throttle",Scale=1.000000,Key=UpArrow)
++AxisMappings=(AxisName="Throttle",Scale=-1.000000,Key=DownArrow)
++AxisMappings=(AxisName="Throttle",Scale=1.000000,Key=Gamepad_RightTrigger)
++AxisMappings=(AxisName="Throttle",Scale=-1.000000,Key=Gamepad_LeftTrigger)
 DefaultPlayerInputClass=/Script/EnhancedInput.EnhancedPlayerInput
 DefaultInputComponentClass=/Script/EnhancedInput.EnhancedInputComponent
 DefaultTouchInterface=/Engine/MobileResources/HUD/DefaultVirtualJoysticks.DefaultVirtualJoysticks

--- a/GAME_DESIGN.md
+++ b/GAME_DESIGN.md
@@ -6,8 +6,8 @@ A meditative, exploration-focused bike riding game where players navigate an end
 ## Gameplay Mechanics
 
 ### Primary Interaction
-- **Single Input System**: At every intersection, fork, or branching path, players choose LEFT or RIGHT
-- **Automatic Forward Movement**: The bike maintains a steady, comfortable pace between decision points
+- **Manual Bike Control**: Players steer freely and manage their speed with throttle and brakes
+- **Intersection Choices**: At forks or junctions, players still choose LEFT or RIGHT to explore new paths
 - **No Failure States**: Every choice leads somewhere interesting - there are no wrong turns, only different discoveries
 
 ### Decision Points

--- a/Source/BikeAdventure/Core/BikeCharacter.cpp
+++ b/Source/BikeAdventure/Core/BikeCharacter.cpp
@@ -73,27 +73,34 @@ void ABikeCharacter::Tick(float DeltaTime)
 {
 	Super::Tick(DeltaTime);
 
-	// Update movement component
-	if (BikeMovement && RootComponent)
-	{
-		BikeMovement->SetSteering(SteeringInput);
-		BikeMovement->UpdateMovement(DeltaTime);
-	}
+        // Update movement component
+        if (BikeMovement && RootComponent)
+        {
+                BikeMovement->SetSteering(SteeringInput);
+               BikeMovement->SetThrottle(ThrottleInput);
+                BikeMovement->UpdateMovement(DeltaTime);
+        }
 }
 
 void ABikeCharacter::SetupPlayerInputComponent(UInputComponent* PlayerInputComponent)
 {
-	Super::SetupPlayerInputComponent(PlayerInputComponent);
+        Super::SetupPlayerInputComponent(PlayerInputComponent);
 
-	// Bind traditional input actions
-	PlayerInputComponent->BindAxis("Turn", this, &ABikeCharacter::HandleTurnInput);
-	PlayerInputComponent->BindAction("LeftChoice", IE_Pressed, this, &ABikeCharacter::HandleLeftChoice);
-	PlayerInputComponent->BindAction("RightChoice", IE_Pressed, this, &ABikeCharacter::HandleRightChoice);
+        // Bind traditional input actions
+       PlayerInputComponent->BindAxis("Turn", this, &ABikeCharacter::HandleTurnInput);
+       PlayerInputComponent->BindAxis("Throttle", this, &ABikeCharacter::HandleThrottleInput);
+        PlayerInputComponent->BindAction("LeftChoice", IE_Pressed, this, &ABikeCharacter::HandleLeftChoice);
+        PlayerInputComponent->BindAction("RightChoice", IE_Pressed, this, &ABikeCharacter::HandleRightChoice);
 }
 
 void ABikeCharacter::HandleTurnInput(float Value)
 {
-	SteeringInput = FMath::Clamp(Value, -1.0f, 1.0f);
+        SteeringInput = FMath::Clamp(Value, -1.0f, 1.0f);
+}
+
+void ABikeCharacter::HandleThrottleInput(float Value)
+{
+       ThrottleInput = FMath::Clamp(Value, 0.0f, 1.0f);
 }
 
 void ABikeCharacter::HandleLeftChoice()

--- a/Source/BikeAdventure/Core/BikeCharacter.h
+++ b/Source/BikeAdventure/Core/BikeCharacter.h
@@ -13,7 +13,7 @@ class AIntersection;
 
 /**
  * Physics-based bike character for meditative exploration
- * Features automatic forward movement with left/right steering control
+ * Features manual throttle and steering control
  */
 UCLASS()
 class BIKEADVENTURE_API ABikeCharacter : public APawn
@@ -57,9 +57,13 @@ protected:
 
 	//~ Input Handling
 
-	/** Handle left/right turning input */
-	UFUNCTION(BlueprintCallable, Category = "Input")
-	void HandleTurnInput(float Value);
+        /** Handle left/right turning input */
+        UFUNCTION(BlueprintCallable, Category = "Input")
+        void HandleTurnInput(float Value);
+
+       /** Handle throttle input */
+       UFUNCTION(BlueprintCallable, Category = "Input")
+       void HandleThrottleInput(float Value);
 
 	/** Handle intersection choice input (left direction) */
 	UFUNCTION(BlueprintCallable, Category = "Input")
@@ -101,13 +105,17 @@ public:
 	AIntersection* GetCurrentIntersection() const { return CurrentIntersection; }
 
 protected:
-	/** Current intersection the bike is at (null if not at intersection) */
-	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Gameplay")
-	TObjectPtr<AIntersection> CurrentIntersection;
+        /** Current intersection the bike is at (null if not at intersection) */
+        UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Gameplay")
+        TObjectPtr<AIntersection> CurrentIntersection;
 
-	/** Current steering input value (-1 to 1) */
-	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Input")
-	float SteeringInput = 0.0f;
+        /** Current steering input value (-1 to 1) */
+        UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Input")
+        float SteeringInput = 0.0f;
+
+       /** Current throttle input value (0 to 1) */
+       UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Input")
+       float ThrottleInput = 0.0f;
 
 private:
 	/** Set up default component values and relationships */

--- a/Source/BikeAdventure/Systems/BikeMovementComponent.cpp
+++ b/Source/BikeAdventure/Systems/BikeMovementComponent.cpp
@@ -68,7 +68,12 @@ void UBikeMovementComponent::UpdateMovement(float DeltaTime)
 
 void UBikeMovementComponent::SetSteering(float SteeringInput)
 {
-	SteeringValue = FMath::Clamp(SteeringInput, -1.0f, 1.0f);
+        SteeringValue = FMath::Clamp(SteeringInput, -1.0f, 1.0f);
+}
+
+void UBikeMovementComponent::SetThrottle(float ThrottleInput)
+{
+       ThrottleValue = FMath::Clamp(ThrottleInput, 0.0f, 1.0f);
 }
 
 void UBikeMovementComponent::SetIntersectionMode(bool bEnabled)
@@ -79,17 +84,14 @@ void UBikeMovementComponent::SetIntersectionMode(bool bEnabled)
 
 void UBikeMovementComponent::UpdateForwardMovement(float DeltaTime)
 {
-	float TargetSpeed = GetTargetForwardSpeed();
-	
-	// Smooth acceleration/deceleration to target speed
-	float AccelerationRate = (CurrentForwardSpeed < TargetSpeed) ? 800.0f : 1200.0f; // Faster deceleration
-	CurrentForwardSpeed = SmoothInterp(CurrentForwardSpeed, TargetSpeed, AccelerationRate, DeltaTime);
+        float TargetSpeed = GetTargetForwardSpeed();
 
-	// Apply air resistance (subtle effect)
-	CurrentForwardSpeed *= (1.0f - AirResistance * DeltaTime);
-	
-	// Ensure minimum speed (bike never stops completely)
-	CurrentForwardSpeed = FMath::Max(CurrentForwardSpeed, TargetSpeed * 0.1f);
+        // Smooth acceleration/deceleration to target speed
+        float AccelerationRate = (CurrentForwardSpeed < TargetSpeed) ? 800.0f : 1200.0f; // Faster deceleration
+        CurrentForwardSpeed = SmoothInterp(CurrentForwardSpeed, TargetSpeed, AccelerationRate, DeltaTime);
+
+        // Apply air resistance (subtle effect)
+        CurrentForwardSpeed *= (1.0f - AirResistance * DeltaTime);
 }
 
 void UBikeMovementComponent::UpdateSteering(float DeltaTime)
@@ -182,7 +184,8 @@ void UBikeMovementComponent::ApplyMovement(const FVector& MovementVector, float 
 
 float UBikeMovementComponent::GetTargetForwardSpeed() const
 {
-	return bIntersectionMode ? IntersectionSpeed : ForwardSpeed;
+       float MaxSpeed = bIntersectionMode ? IntersectionSpeed : ForwardSpeed;
+       return ThrottleValue * MaxSpeed;
 }
 
 float UBikeMovementComponent::SmoothInterp(float Current, float Target, float Speed, float DeltaTime) const

--- a/Source/BikeAdventure/Systems/BikeMovementComponent.h
+++ b/Source/BikeAdventure/Systems/BikeMovementComponent.h
@@ -7,7 +7,7 @@
 
 /**
  * Custom movement component for physics-based bike movement
- * Handles automatic forward movement with smooth turning mechanics
+ * Handles player-controlled forward movement with smooth turning mechanics
  */
 UCLASS(ClassGroup=(Custom), meta=(BlueprintSpawnableComponent))
 class BIKEADVENTURE_API UBikeMovementComponent : public UPawnMovementComponent
@@ -21,11 +21,14 @@ protected:
 	virtual void BeginPlay() override;
 
 public:
-	/** Called every frame to update movement */
-	virtual void UpdateMovement(float DeltaTime);
+        /** Called every frame to update movement */
+        virtual void UpdateMovement(float DeltaTime);
 
-	/** Set steering input (-1.0 to 1.0) */
-	void SetSteering(float SteeringInput);
+        /** Set steering input (-1.0 to 1.0) */
+        void SetSteering(float SteeringInput);
+
+       /** Set throttle input (0.0 to 1.0) */
+       void SetThrottle(float ThrottleInput);
 
 	/** Get current forward speed */
 	float GetCurrentSpeed() const { return CurrentForwardSpeed; }
@@ -74,13 +77,17 @@ public:
 	float GroundTraceDistance = 150.0f;
 
 protected:
-	/** Current forward velocity */
-	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Movement|State")
-	float CurrentForwardSpeed = 0.0f;
+        /** Current forward velocity */
+        UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Movement|State")
+        float CurrentForwardSpeed = 0.0f;
 
-	/** Current steering input value */
-	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Movement|State")
-	float SteeringValue = 0.0f;
+        /** Current steering input value */
+        UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Movement|State")
+        float SteeringValue = 0.0f;
+
+       /** Current throttle input value */
+       UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Movement|State")
+       float ThrottleValue = 0.0f;
 
 	/** Current turn rate being applied */
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Movement|State")


### PR DESCRIPTION
## Summary
- allow player-controlled throttle and steering via BikeMovementComponent and BikeCharacter
- update input mappings and design docs for manual biking

## Testing
- `python Scripts/GauntletTests/BikeAdventureGauntletTest.py` *(fails: FPS too low)*

------
https://chatgpt.com/codex/tasks/task_e_68af0eeb0e5c83329c50672e94479f19