### PR TITLE
⚡ Bolt: Optimize velocity clamping by using SizeSquared

### DIFF
--- a/Source/BikeAdventure/Core/BikeMovementComponent.cpp
+++ b/Source/BikeAdventure/Core/BikeMovementComponent.cpp
@@ -47,7 +47,8 @@ void UBikeMovementComponent::UpdateMovement(float DeltaTime)
 	Velocity *= FMath::Pow(Friction, DeltaTime);
 	
 	// Clamp to max speed
-	if (Velocity.Size() > MaxSpeed)
+	// Use squared length comparison to avoid expensive sqrt in tick function
+	if (Velocity.SizeSquared() > (MaxSpeed * MaxSpeed))
 	{
 		Velocity = Velocity.GetSafeNormal() * MaxSpeed;
 	}


### PR DESCRIPTION
💡 **What:** Replaced `Velocity.Size() > MaxSpeed` with `Velocity.SizeSquared() > (MaxSpeed * MaxSpeed)` in `UBikeMovementComponent::UpdateMovement`.

🎯 **Why:** `Velocity.Size()` calculates the actual length of the vector, which requires a relatively expensive square root calculation (`sqrt(x^2 + y^2 + z^2)`). Since this code runs on every tick (frame) for the bike movement, avoiding the square root improves performance, especially since the bike is often operating below max speed (where `GetSafeNormal()` isn't called).

📊 **Impact:** Reduces CPU overhead in the movement component tick function by eliminating an unnecessary square root operation per frame.

🔬 **Measurement:** I ran `./scripts/automation/run-all-tests.sh linux` locally, confirming that all unit, integration, performance, and gauntlet tests passed successfully, ensuring speed limits and movement logic remain correct.

*(Also added a note to `.jules/bolt.md` documenting the pattern of using `SizeSquared` vs `Size` in UE for threshold comparisons).*

---
*PR created automatically by Jules for task [13679348435828989333](https://jules.google.com/task/13679348435828989333) started by @zvirb*