### PR TITLE
feat: Add programmatic asset generation for Desert biome

### DIFF
--- a/Source/BikeAdventure/Systems/AdvancedBiomePCGSettings.cpp
+++ b/Source/BikeAdventure/Systems/AdvancedBiomePCGSettings.cpp
@@ -50,6 +50,20 @@ UMountainPCGSettings::UMountainPCGSettings()
     AlpinePlantMeshes.Add(TSoftObjectPtr<UStaticMesh>(FSoftObjectPath(TEXT("/Game/Art/Models/Mountains/SM_AlpinePlant.SM_AlpinePlant"))));
 }
 
+// Desert PCG Settings
+UDesertPCGSettings::UDesertPCGSettings()
+{
+    BiomeType = EBiomeType::Desert;
+    CactusDensity = 0.4f;
+    RockDensity = 0.3f;
+    DuneVariation = 1.0f;
+    OasisChance = 0.05f;
+
+    // Add programmatic assets to arrays
+    CactusMeshes.Add(TSoftObjectPtr<UStaticMesh>(FSoftObjectPath(TEXT("/Game/Art/Models/Desert/SM_DesertCactus.SM_DesertCactus"))));
+    RockMeshes.Add(TSoftObjectPtr<UStaticMesh>(FSoftObjectPath(TEXT("/Game/Art/Models/Desert/SM_DesertRock.SM_DesertRock"))));
+}
+
 // Wetlands PCG Settings
 UWetlandsPCGSettings::UWetlandsPCGSettings()
 {
@@ -125,6 +139,13 @@ bool FAdvancedBiomeGenerationElement::ExecuteInternal(FPCGContext* Context) cons
             }
             break;
             
+        case EBiomeType::Desert:
+            if (const UDesertPCGSettings* DesertSettings = Cast<UDesertPCGSettings>(Settings))
+            {
+                GenerateDesertLayout(Context, DesertSettings, OutputPoints);
+            }
+            break;
+
         default:
             // Fall back to base implementation for other biomes
             {
@@ -553,6 +574,61 @@ void FAdvancedBiomeGenerationElement::GenerateWetlandsEcosystem(FPCGContext* Con
     }
 }
 
+void FAdvancedBiomeGenerationElement::GenerateDesertLayout(FPCGContext* Context, const UDesertPCGSettings* Settings, TArray<FPCGPoint>& OutPoints) const
+{
+    FRandomStream Random(FMath::Rand());
+
+    // Generate cacti
+    int32 NumCacti = FMath::RoundToInt(200.0f * Settings->CactusDensity);
+    for (int32 i = 0; i < NumCacti; i++)
+    {
+        FVector Location(
+            Random.FRandRange(-2000.0f, 2000.0f),
+            Random.FRandRange(-2000.0f, 2000.0f),
+            0.0f
+        );
+
+        FRotator Rotation(
+            Random.FRandRange(-5.0f, 5.0f),
+            Random.FRandRange(0.0f, 360.0f),
+            Random.FRandRange(-5.0f, 5.0f)
+        );
+
+        FVector Scale(Random.FRandRange(0.8f, 1.5f));
+
+        FPCGPoint CactusPoint = CreateBiomePoint(Location, Rotation, Scale, EBiomeType::Desert, 0);
+        CactusPoint.Density = Settings->CactusDensity;
+        ApplyBiomeAttributes(CactusPoint, EBiomeType::Desert, TEXT("Cactus"));
+
+        OutPoints.Add(CactusPoint);
+    }
+
+    // Generate rocks
+    int32 NumRocks = FMath::RoundToInt(150.0f * Settings->RockDensity);
+    for (int32 i = 0; i < NumRocks; i++)
+    {
+        FVector Location(
+            Random.FRandRange(-2000.0f, 2000.0f),
+            Random.FRandRange(-2000.0f, 2000.0f),
+            0.0f
+        );
+
+        FRotator Rotation(
+            Random.FRandRange(-20.0f, 20.0f),
+            Random.FRandRange(0.0f, 360.0f),
+            Random.FRandRange(-20.0f, 20.0f)
+        );
+
+        FVector Scale(Random.FRandRange(0.5f, 2.5f));
+
+        FPCGPoint RockPoint = CreateBiomePoint(Location, Rotation, Scale, EBiomeType::Desert, 1);
+        RockPoint.Density = Settings->RockDensity;
+        ApplyBiomeAttributes(RockPoint, EBiomeType::Desert, TEXT("Rock"));
+
+        OutPoints.Add(RockPoint);
+    }
+}
+
 FPCGPoint FAdvancedBiomeGenerationElement::CreateBiomePoint(const FVector& Location, const FRotator& Rotation, const FVector& Scale, EBiomeType BiomeType, int32 MeshIndex) const
 {
     FPCGPoint Point;
@@ -584,6 +660,9 @@ void FAdvancedBiomeGenerationElement::ApplyBiomeAttributes(FPCGPoint& Point, EBi
             break;
         case EBiomeType::Wetlands:
             Point.Color = FVector4(0.3f, 0.5f, 0.8f, 1.0f); // Blue for wetlands
+            break;
+        case EBiomeType::Desert:
+            Point.Color = FVector4(0.8f, 0.7f, 0.4f, 1.0f); // Sand/Yellow for desert
             break;
         default:
             Point.Color = FVector4(1.0f, 1.0f, 1.0f, 1.0f);

--- a/Source/BikeAdventure/Systems/AdvancedBiomePCGSettings.h
+++ b/Source/BikeAdventure/Systems/AdvancedBiomePCGSettings.h
@@ -199,6 +199,42 @@ public:
 };
 
 /**
+ * Desert-specific PCG settings with dunes and cacti
+ */
+UCLASS(BlueprintType, Blueprintable)
+class BIKEADVENTURE_API UDesertPCGSettings : public UBiomePCGSettings
+{
+    GENERATED_BODY()
+
+public:
+    UDesertPCGSettings();
+
+    // Cactus density
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "Desert Generation", meta = (ClampMin = "0.0", ClampMax = "1.0"))
+    float CactusDensity;
+
+    // Rock formation density
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "Desert Generation", meta = (ClampMin = "0.0", ClampMax = "1.0"))
+    float RockDensity;
+
+    // Sand dune variation intensity
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "Desert Generation", meta = (ClampMin = "0.0", ClampMax = "2.0"))
+    float DuneVariation;
+
+    // Oasis probability
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "Desert Generation", meta = (ClampMin = "0.0", ClampMax = "1.0"))
+    float OasisChance;
+
+    // Cactus and vegetation meshes
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "Desert Assets")
+    TArray<TSoftObjectPtr<UStaticMesh>> CactusMeshes;
+
+    // Sandstone and rock meshes
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "Desert Assets")
+    TArray<TSoftObjectPtr<UStaticMesh>> RockMeshes;
+};
+
+/**
  * Advanced PCG element for specialized biome generation
  */
 class BIKEADVENTURE_API FAdvancedBiomeGenerationElement : public IPCGElement
@@ -223,6 +259,9 @@ private:
 
     // Generate wetlands ecosystem
     void GenerateWetlandsEcosystem(FPCGContext* Context, const UWetlandsPCGSettings* Settings, TArray<FPCGPoint>& OutPoints) const;
+
+    // Generate desert landscape
+    void GenerateDesertLayout(FPCGContext* Context, const UDesertPCGSettings* Settings, TArray<FPCGPoint>& OutPoints) const;
 
     // Helper function to create point with biome-specific attributes
     FPCGPoint CreateBiomePoint(const FVector& Location, const FRotator& Rotation, const FVector& Scale, EBiomeType BiomeType, int32 MeshIndex = 0) const;

--- a/docs/ART_PIPELINE.md
+++ b/docs/ART_PIPELINE.md
@@ -26,13 +26,14 @@ As part of the goal to dynamically generate content, there are Python scripts in
    exec(open("C:/Path/To/Your/Repo/scripts/asset_generation/generate_urban_assets.py").read())
    exec(open("C:/Path/To/Your/Repo/scripts/asset_generation/generate_countryside_assets.py").read())
    exec(open("C:/Path/To/Your/Repo/scripts/asset_generation/generate_wetlands_assets.py").read())
+   exec(open("C:/Path/To/Your/Repo/scripts/asset_generation/generate_desert_assets.py").read())
    ```
-   Or if you prefer right-clicking, you can drag and drop `generate_mountain_assets.py`, `generate_urban_assets.py`, `generate_countryside_assets.py`, or `generate_wetlands_assets.py` into the Content Browser, right click the asset, and select **Run Editor Utility Python Script**.
+   Or if you prefer right-clicking, you can drag and drop `generate_mountain_assets.py`, `generate_urban_assets.py`, `generate_countryside_assets.py`, `generate_wetlands_assets.py`, or `generate_desert_assets.py` into the Content Browser, right click the asset, and select **Run Editor Utility Python Script**.
 
 ### Asset Outputs
 
 The scripts will:
-- Create `/Game/Art/Models/Mountains/`, `/Game/Art/Models/Urban/`, `/Game/Art/Models/Countryside/`, and `/Game/Art/Materials/`.
+- Create `/Game/Art/Models/Mountains/`, `/Game/Art/Models/Urban/`, `/Game/Art/Models/Countryside/`, `/Game/Art/Models/Desert/`, and `/Game/Art/Materials/`.
 - Procedurally generate `SM_MountainRock` and `SM_AlpinePlant` for Mountains, and `SM_UrbanBuilding` and `SM_UrbanBench` for Urban, using simple primitive and geometry boolean/noise functions.
 - Procedurally construct master materials like `M_StylizedMaster` and `M_StylizedUrban`, and derived material instances (e.g., `MI_MountainRock`, `MI_UrbanBuilding`).
 - Assign these material instances to the corresponding static meshes.

--- a/scripts/asset_generation/generate_desert_assets.py
+++ b/scripts/asset_generation/generate_desert_assets.py
@@ -1,0 +1,341 @@
+import unreal
+import sys
+
+def ensure_directory(path):
+    if not unreal.EditorAssetLibrary.does_directory_exist(path):
+        unreal.EditorAssetLibrary.make_directory(path)
+
+def create_master_material(mat_path):
+    if unreal.EditorAssetLibrary.does_asset_exist(mat_path):
+        return unreal.EditorAssetLibrary.load_asset(mat_path)
+
+    mat_factory = unreal.MaterialFactoryNew()
+    asset_tools = unreal.AssetToolsHelpers.get_asset_tools()
+
+    # Extract package path and asset name
+    pkg_path = '/'.join(mat_path.split('/')[:-1])
+    asset_name = mat_path.split('/')[-1]
+
+    mat = asset_tools.create_asset(
+        asset_name=asset_name,
+        package_path=pkg_path,
+        asset_class=unreal.Material,
+        factory=mat_factory
+    )
+
+    if not mat:
+        return None
+
+    # Base Color Parameter
+    base_color_node = unreal.MaterialEditingLibrary.create_material_expression(
+        mat, unreal.MaterialExpressionVectorParameter, -400, 0
+    )
+    base_color_node.set_editor_property("parameter_name", "BaseColor")
+    base_color_node.set_editor_property("default_value", unreal.LinearColor(1.0, 1.0, 1.0, 1.0))
+
+    # Roughness Parameter
+    roughness_node = unreal.MaterialEditingLibrary.create_material_expression(
+        mat, unreal.MaterialExpressionScalarParameter, -400, 200
+    )
+    roughness_node.set_editor_property("parameter_name", "Roughness")
+    roughness_node.set_editor_property("default_value", 0.5)
+
+    # Simple Noise Node to add stylized gradient/noise feel
+    noise_node = unreal.MaterialEditingLibrary.create_material_expression(
+        mat, unreal.MaterialExpressionNoise, -400, -200
+    )
+    noise_node.set_editor_property("scale", 0.1)
+
+    # Multiply Noise with BaseColor
+    multiply_node = unreal.MaterialEditingLibrary.create_material_expression(
+        mat, unreal.MaterialExpressionMultiply, -200, 0
+    )
+
+    # Connect BaseColor and Noise to Multiply
+    unreal.MaterialEditingLibrary.connect_material_expressions(
+        base_color_node, "", multiply_node, "A"
+    )
+    unreal.MaterialEditingLibrary.connect_material_expressions(
+        noise_node, "", multiply_node, "B"
+    )
+
+    unreal.MaterialEditingLibrary.connect_material_property(
+        multiply_node, "", unreal.MaterialProperty.MP_BASE_COLOR
+    )
+    unreal.MaterialEditingLibrary.connect_material_property(
+        roughness_node, "", unreal.MaterialProperty.MP_ROUGHNESS
+    )
+
+    unreal.MaterialEditingLibrary.recompile_material(mat)
+    return mat
+
+def create_material_instance(mat_inst_path, parent_mat, color, roughness):
+    if unreal.EditorAssetLibrary.does_asset_exist(mat_inst_path):
+        mat_inst = unreal.EditorAssetLibrary.load_asset(mat_inst_path)
+    else:
+        mat_inst_factory = unreal.MaterialInstanceConstantFactoryNew()
+        asset_tools = unreal.AssetToolsHelpers.get_asset_tools()
+
+        pkg_path = '/'.join(mat_inst_path.split('/')[:-1])
+        asset_name = mat_inst_path.split('/')[-1]
+
+        mat_inst = asset_tools.create_asset(
+            asset_name=asset_name,
+            package_path=pkg_path,
+            asset_class=unreal.MaterialInstanceConstant,
+            factory=mat_inst_factory
+        )
+
+        if mat_inst and parent_mat:
+            unreal.MaterialEditingLibrary.set_material_instance_parent(mat_inst, parent_mat)
+
+    if mat_inst:
+        unreal.MaterialEditingLibrary.set_material_instance_vector_parameter_value(
+            mat_inst, "BaseColor", unreal.LinearColor(color[0], color[1], color[2], color[3])
+        )
+        unreal.MaterialEditingLibrary.set_material_instance_scalar_parameter_value(
+            mat_inst, "Roughness", roughness
+        )
+        unreal.MaterialEditingLibrary.update_material_instance(mat_inst)
+
+    return mat_inst
+
+def assign_material_to_mesh(static_mesh, material_instance):
+    if not static_mesh or not material_instance:
+        return
+
+    # Standard approach to set material on a static mesh in UE5 Python
+    materials = static_mesh.get_editor_property('static_materials')
+
+    if not materials or len(materials) == 0:
+        # Create a new element
+        new_mat = unreal.StaticMaterial()
+        new_mat.material_interface = material_instance
+        materials = [new_mat]
+    else:
+        # Update first element
+        materials[0].material_interface = material_instance
+
+    static_mesh.set_editor_property('static_materials', materials)
+
+def generate_desert_cactus(mesh_path, mat_inst):
+    if unreal.EditorAssetLibrary.does_asset_exist(mesh_path):
+        print(f"Asset already exists: {mesh_path}")
+        return
+
+    try:
+        dyn_mesh = unreal.GeometryScriptLibrary_CreateNewDynamicMesh.create_new_dynamic_mesh()
+    except AttributeError:
+        try:
+            dyn_mesh = unreal.GeometryScript_AssetUtils.create_new_dynamic_mesh()
+        except AttributeError:
+            dyn_mesh = unreal.DynamicMesh()
+
+    options = unreal.GeometryScriptPrimitiveOptions()
+    transform = unreal.Transform()
+
+    # Create cactus base
+    try:
+        if hasattr(unreal, "GeometryScriptLibrary_MeshPrimitiveFunctions"):
+            unreal.GeometryScriptLibrary_MeshPrimitiveFunctions.append_cylinder(
+                target_mesh=dyn_mesh,
+                primitive_options=options,
+                transform=transform,
+                radius=30.0,
+                height=200.0,
+                radial_steps=8,
+                height_steps=1,
+                capped=True,
+                origin=unreal.GeometryScriptPrimitiveOriginMode.BASE
+            )
+
+            # Left arm
+            arm1_transform = unreal.Transform()
+            arm1_transform.translation = [-40.0, 0.0, 100.0]
+            unreal.GeometryScriptLibrary_MeshPrimitiveFunctions.append_cylinder(
+                target_mesh=dyn_mesh,
+                primitive_options=options,
+                transform=arm1_transform,
+                radius=20.0,
+                height=80.0,
+                radial_steps=8,
+                height_steps=1,
+                capped=True,
+                origin=unreal.GeometryScriptPrimitiveOriginMode.BASE
+            )
+
+            # Right arm
+            arm2_transform = unreal.Transform()
+            arm2_transform.translation = [40.0, 0.0, 130.0]
+            unreal.GeometryScriptLibrary_MeshPrimitiveFunctions.append_cylinder(
+                target_mesh=dyn_mesh,
+                primitive_options=options,
+                transform=arm2_transform,
+                radius=20.0,
+                height=60.0,
+                radial_steps=8,
+                height_steps=1,
+                capped=True,
+                origin=unreal.GeometryScriptPrimitiveOriginMode.BASE
+            )
+        else:
+            unreal.GeometryScript_MeshPrimitiveFunctions.append_cylinder(
+                target_mesh=dyn_mesh,
+                primitive_options=options,
+                transform=transform,
+                radius=30.0,
+                height=200.0,
+                radial_steps=8,
+                height_steps=1,
+                capped=True,
+                origin=unreal.GeometryScriptPrimitiveOriginMode.BASE
+            )
+
+            arm1_transform = unreal.Transform()
+            arm1_transform.translation = [-40.0, 0.0, 100.0]
+            unreal.GeometryScript_MeshPrimitiveFunctions.append_cylinder(
+                target_mesh=dyn_mesh,
+                primitive_options=options,
+                transform=arm1_transform,
+                radius=20.0,
+                height=80.0,
+                radial_steps=8,
+                height_steps=1,
+                capped=True,
+                origin=unreal.GeometryScriptPrimitiveOriginMode.BASE
+            )
+
+            arm2_transform = unreal.Transform()
+            arm2_transform.translation = [40.0, 0.0, 130.0]
+            unreal.GeometryScript_MeshPrimitiveFunctions.append_cylinder(
+                target_mesh=dyn_mesh,
+                primitive_options=options,
+                transform=arm2_transform,
+                radius=20.0,
+                height=60.0,
+                radial_steps=8,
+                height_steps=1,
+                capped=True,
+                origin=unreal.GeometryScriptPrimitiveOriginMode.BASE
+            )
+    except Exception as e:
+        print(f"GeometryScript generation failed: {e}")
+        return
+
+    create_options = unreal.GeometryScriptCreateNewStaticMeshAssetOptions()
+    try:
+        if hasattr(unreal, "GeometryScriptLibrary_CreateNewStaticMeshAssetFromDynamicMesh"):
+            static_mesh = unreal.GeometryScriptLibrary_CreateNewStaticMeshAssetFromDynamicMesh.create_new_static_mesh_asset_from_dynamic_mesh(
+                dynamic_mesh=dyn_mesh,
+                asset_path_and_name=mesh_path,
+                options=create_options
+            )
+        else:
+            static_mesh = unreal.GeometryScript_AssetUtils.create_new_static_mesh_asset_from_dynamic_mesh(
+                dynamic_mesh=dyn_mesh,
+                asset_path_and_name=mesh_path,
+                options=create_options
+            )
+
+        # Apply material
+        assign_material_to_mesh(static_mesh, mat_inst)
+    except Exception as e:
+        print(f"GeometryScript bake failed: {e}")
+
+def generate_desert_rock(mesh_path, mat_inst):
+    if unreal.EditorAssetLibrary.does_asset_exist(mesh_path):
+        print(f"Asset already exists: {mesh_path}")
+        return
+
+    try:
+        dyn_mesh = unreal.GeometryScriptLibrary_CreateNewDynamicMesh.create_new_dynamic_mesh()
+    except AttributeError:
+        try:
+            dyn_mesh = unreal.GeometryScript_AssetUtils.create_new_dynamic_mesh()
+        except AttributeError:
+            dyn_mesh = unreal.DynamicMesh()
+
+    options = unreal.GeometryScriptPrimitiveOptions()
+    transform = unreal.Transform()
+
+    # Create sandstone rock base
+    try:
+        if hasattr(unreal, "GeometryScriptLibrary_MeshPrimitiveFunctions"):
+            unreal.GeometryScriptLibrary_MeshPrimitiveFunctions.append_box(
+                target_mesh=dyn_mesh,
+                primitive_options=options,
+                transform=transform,
+                dimension_x=120.0,
+                dimension_y=150.0,
+                dimension_z=60.0,
+                steps_x=3,
+                steps_y=3,
+                steps_z=2,
+                origin=unreal.GeometryScriptPrimitiveOriginMode.BASE
+            )
+        else:
+            unreal.GeometryScript_MeshPrimitiveFunctions.append_box(
+                target_mesh=dyn_mesh,
+                primitive_options=options,
+                transform=transform,
+                dimension_x=120.0,
+                dimension_y=150.0,
+                dimension_z=60.0,
+                steps_x=3,
+                steps_y=3,
+                steps_z=2,
+                origin=unreal.GeometryScriptPrimitiveOriginMode.BASE
+            )
+    except Exception as e:
+        print(f"GeometryScript generation failed: {e}")
+        return
+
+    create_options = unreal.GeometryScriptCreateNewStaticMeshAssetOptions()
+    try:
+        if hasattr(unreal, "GeometryScriptLibrary_CreateNewStaticMeshAssetFromDynamicMesh"):
+            static_mesh = unreal.GeometryScriptLibrary_CreateNewStaticMeshAssetFromDynamicMesh.create_new_static_mesh_asset_from_dynamic_mesh(
+                dynamic_mesh=dyn_mesh,
+                asset_path_and_name=mesh_path,
+                options=create_options
+            )
+        else:
+            static_mesh = unreal.GeometryScript_AssetUtils.create_new_static_mesh_asset_from_dynamic_mesh(
+                dynamic_mesh=dyn_mesh,
+                asset_path_and_name=mesh_path,
+                options=create_options
+            )
+
+        # Apply material
+        assign_material_to_mesh(static_mesh, mat_inst)
+    except Exception as e:
+        print(f"GeometryScript bake failed: {e}")
+
+def main():
+    base_dir = '/Game/Art/Models/Desert'
+    mat_dir = '/Game/Art/Materials'
+
+    ensure_directory(base_dir)
+    ensure_directory(mat_dir)
+
+    # Procedural Material Generation
+    master_mat_path = f"{mat_dir}/M_StylizedDesert"
+    master_mat = create_master_material(master_mat_path)
+
+    # Procedural Material Instances
+    cactus_mat_path = f"{mat_dir}/MI_DesertCactus"
+    cactus_mat = create_material_instance(cactus_mat_path, master_mat, [0.3, 0.6, 0.2, 1.0], 0.7)
+
+    rock_mat_path = f"{mat_dir}/MI_DesertRock"
+    rock_mat = create_material_instance(rock_mat_path, master_mat, [0.8, 0.6, 0.4, 1.0], 0.9)
+
+    # Programmatic 3D Modeling
+    cactus_mesh_path = f"{base_dir}/SM_DesertCactus"
+    generate_desert_cactus(cactus_mesh_path, cactus_mat)
+
+    rock_mesh_path = f"{base_dir}/SM_DesertRock"
+    generate_desert_rock(rock_mesh_path, rock_mat)
+
+    print("Asset generation for Desert biome complete.")
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This change implements the first iteration of programmatic art generation for the missing biomes, specifically targeting the **Desert** biome.

It introduces a new Python script (`scripts/asset_generation/generate_desert_assets.py`) that utilizes Unreal Engine 5's Geometry Scripting and Procedural Material generation to construct low-poly, stylized 3D assets (`SM_DesertCactus`, `SM_DesertRock`). The script also builds a master material (`M_StylizedDesert`) and handles instance assignments automatically.

The core C++ PCG system (`AdvancedBiomePCGSettings`) was updated to include the `UDesertPCGSettings` configuration, integrating the new `TSoftObjectPtr` paths so the generated assets are populated within the world by the `UBiomeGenerator`. Documentation was also updated to reflect the new script.

---
*PR created automatically by Jules for task [8931977590688537114](https://jules.google.com/task/8931977590688537114) started by @zvirb*