### PR TITLE
feat: Procedurally generate Forest biome assets using UE5 Geometry Scripting

### DIFF
--- a/Source/BikeAdventure/Systems/AdvancedBiomePCGSettings.cpp
+++ b/Source/BikeAdventure/Systems/AdvancedBiomePCGSettings.cpp
@@ -5,6 +5,18 @@
 #include "Engine/Engine.h"
 #include "AssetRegistry/AssetRegistryModule.h"
 
+// Forest PCG Settings
+UForestPCGSettings::UForestPCGSettings()
+{
+    BiomeType = EBiomeType::Forest;
+    TreeDensity = 0.4f; // Lowered to meet 60 FPS constraint
+    RockDensity = 0.3f;
+
+    // Add programmatic assets to arrays
+    TreeMeshes.Add(TSoftObjectPtr<UStaticMesh>(FSoftObjectPath(TEXT("/Game/Art/Models/Forest/SM_PineTree.SM_PineTree"))));
+    RockMeshes.Add(TSoftObjectPtr<UStaticMesh>(FSoftObjectPath(TEXT("/Game/Art/Models/Forest/SM_ForestRock.SM_ForestRock"))));
+}
+
 // Urban PCG Settings
 UUrbanPCGSettings::UUrbanPCGSettings()
 {
@@ -111,6 +123,13 @@ bool FAdvancedBiomeGenerationElement::ExecuteInternal(FPCGContext* Context) cons
     // Generate points based on biome type
     switch (Settings->BiomeType)
     {
+        case EBiomeType::Forest:
+            if (const UForestPCGSettings* ForestSettings = Cast<UForestPCGSettings>(Settings))
+            {
+                GenerateForestLayout(Context, ForestSettings, OutputPoints);
+            }
+            break;
+
         case EBiomeType::Urban:
             if (const UUrbanPCGSettings* UrbanSettings = Cast<UUrbanPCGSettings>(Settings))
             {
@@ -175,6 +194,61 @@ bool FAdvancedBiomeGenerationElement::ExecuteInternal(FPCGContext* Context) cons
     
     Context->OutputData.TaggedData.Emplace_GetRef().Data = OutputData;
     return true;
+}
+
+void FAdvancedBiomeGenerationElement::GenerateForestLayout(FPCGContext* Context, const UForestPCGSettings* Settings, TArray<FPCGPoint>& OutPoints) const
+{
+    FRandomStream Random(FMath::Rand());
+
+    // Generate trees
+    int32 NumTrees = FMath::RoundToInt(800.0f * Settings->TreeDensity);
+    for (int32 i = 0; i < NumTrees; i++)
+    {
+        FVector Location(
+            Random.FRandRange(-2000.0f, 2000.0f),
+            Random.FRandRange(-2000.0f, 2000.0f),
+            0.0f
+        );
+
+        FRotator Rotation(
+            Random.FRandRange(-5.0f, 5.0f),
+            Random.FRandRange(0.0f, 360.0f),
+            Random.FRandRange(-5.0f, 5.0f)
+        );
+
+        FVector Scale(Random.FRandRange(0.8f, 1.5f));
+
+        FPCGPoint TreePoint = CreateBiomePoint(Location, Rotation, Scale, EBiomeType::Forest, 0);
+        TreePoint.Density = Settings->TreeDensity;
+        ApplyBiomeAttributes(TreePoint, EBiomeType::Forest, TEXT("Tree"));
+
+        OutPoints.Add(TreePoint);
+    }
+
+    // Generate rocks
+    int32 NumRocks = FMath::RoundToInt(200.0f * Settings->RockDensity);
+    for (int32 i = 0; i < NumRocks; i++)
+    {
+        FVector Location(
+            Random.FRandRange(-2000.0f, 2000.0f),
+            Random.FRandRange(-2000.0f, 2000.0f),
+            0.0f
+        );
+
+        FRotator Rotation(
+            Random.FRandRange(-20.0f, 20.0f),
+            Random.FRandRange(0.0f, 360.0f),
+            Random.FRandRange(-20.0f, 20.0f)
+        );
+
+        FVector Scale(Random.FRandRange(0.5f, 2.0f));
+
+        FPCGPoint RockPoint = CreateBiomePoint(Location, Rotation, Scale, EBiomeType::Forest, 1);
+        RockPoint.Density = Settings->RockDensity;
+        ApplyBiomeAttributes(RockPoint, EBiomeType::Forest, TEXT("Rock"));
+
+        OutPoints.Add(RockPoint);
+    }
 }
 
 void FAdvancedBiomeGenerationElement::GenerateUrbanLayout(FPCGContext* Context, const UUrbanPCGSettings* Settings, TArray<FPCGPoint>& OutPoints) const

--- a/Source/BikeAdventure/Systems/AdvancedBiomePCGSettings.h
+++ b/Source/BikeAdventure/Systems/AdvancedBiomePCGSettings.h
@@ -7,6 +7,34 @@
 #include "AdvancedBiomePCGSettings.generated.h"
 
 /**
+ * Forest-specific PCG settings with trees and rocks
+ */
+UCLASS(BlueprintType, Blueprintable)
+class BIKEADVENTURE_API UForestPCGSettings : public UBiomePCGSettings
+{
+    GENERATED_BODY()
+
+public:
+    UForestPCGSettings();
+
+    // Tree density
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "Forest Generation", meta = (ClampMin = "0.0", ClampMax = "1.0"))
+    float TreeDensity;
+
+    // Rock density
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "Forest Generation", meta = (ClampMin = "0.0", ClampMax = "1.0"))
+    float RockDensity;
+
+    // Tree meshes
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "Forest Assets")
+    TArray<TSoftObjectPtr<UStaticMesh>> TreeMeshes;
+
+    // Rock meshes
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "Forest Assets")
+    TArray<TSoftObjectPtr<UStaticMesh>> RockMeshes;
+};
+
+/**
  * Urban-specific PCG settings with detailed city generation
  */
 UCLASS(BlueprintType, Blueprintable)
@@ -248,6 +276,9 @@ protected:
     virtual bool IsCacheable(const UPCGSettings* InSettings) const override { return true; }
 
 private:
+    // Generate forest layout
+    void GenerateForestLayout(FPCGContext* Context, const UForestPCGSettings* Settings, TArray<FPCGPoint>& OutPoints) const;
+
     // Generate urban layout
     void GenerateUrbanLayout(FPCGContext* Context, const UUrbanPCGSettings* Settings, TArray<FPCGPoint>& OutPoints) const;
 

--- a/docs/ART_PIPELINE.md
+++ b/docs/ART_PIPELINE.md
@@ -22,19 +22,20 @@ As part of the goal to dynamically generate content, there are Python scripts in
    ```python
    import sys
    # Append the path where scripts are if needed, or simply pass the path to execfile
+   exec(open("C:/Path/To/Your/Repo/scripts/asset_generation/generate_forest_assets.py").read())
    exec(open("C:/Path/To/Your/Repo/scripts/asset_generation/generate_mountain_assets.py").read())
    exec(open("C:/Path/To/Your/Repo/scripts/asset_generation/generate_urban_assets.py").read())
    exec(open("C:/Path/To/Your/Repo/scripts/asset_generation/generate_countryside_assets.py").read())
    exec(open("C:/Path/To/Your/Repo/scripts/asset_generation/generate_wetlands_assets.py").read())
    exec(open("C:/Path/To/Your/Repo/scripts/asset_generation/generate_desert_assets.py").read())
    ```
-   Or if you prefer right-clicking, you can drag and drop `generate_mountain_assets.py`, `generate_urban_assets.py`, `generate_countryside_assets.py`, `generate_wetlands_assets.py`, or `generate_desert_assets.py` into the Content Browser, right click the asset, and select **Run Editor Utility Python Script**.
+   Or if you prefer right-clicking, you can drag and drop `generate_forest_assets.py`, `generate_mountain_assets.py`, `generate_urban_assets.py`, `generate_countryside_assets.py`, `generate_wetlands_assets.py`, or `generate_desert_assets.py` into the Content Browser, right click the asset, and select **Run Editor Utility Python Script**.
 
 ### Asset Outputs
 
 The scripts will:
-- Create `/Game/Art/Models/Mountains/`, `/Game/Art/Models/Urban/`, `/Game/Art/Models/Countryside/`, `/Game/Art/Models/Desert/`, and `/Game/Art/Materials/`.
-- Procedurally generate `SM_MountainRock` and `SM_AlpinePlant` for Mountains, and `SM_UrbanBuilding` and `SM_UrbanBench` for Urban, using simple primitive and geometry boolean/noise functions.
+- Create `/Game/Art/Models/Forest/`, `/Game/Art/Models/Mountains/`, `/Game/Art/Models/Urban/`, `/Game/Art/Models/Countryside/`, `/Game/Art/Models/Desert/`, and `/Game/Art/Materials/`.
+- Procedurally generate `SM_PineTree` and `SM_ForestRock` for Forest, `SM_MountainRock` and `SM_AlpinePlant` for Mountains, and `SM_UrbanBuilding` and `SM_UrbanBench` for Urban, using simple primitive and geometry boolean/noise functions.
 - Procedurally construct master materials like `M_StylizedMaster` and `M_StylizedUrban`, and derived material instances (e.g., `MI_MountainRock`, `MI_UrbanBuilding`).
 - Assign these material instances to the corresponding static meshes.
 

--- a/scripts/asset_generation/generate_forest_assets.py
+++ b/scripts/asset_generation/generate_forest_assets.py
@@ -1,0 +1,355 @@
+import unreal
+import sys
+
+def ensure_directory(path):
+    if not unreal.EditorAssetLibrary.does_directory_exist(path):
+        unreal.EditorAssetLibrary.make_directory(path)
+
+def create_master_material(mat_path):
+    if unreal.EditorAssetLibrary.does_asset_exist(mat_path):
+        return unreal.EditorAssetLibrary.load_asset(mat_path)
+
+    mat_factory = unreal.MaterialFactoryNew()
+    asset_tools = unreal.AssetToolsHelpers.get_asset_tools()
+
+    pkg_path = '/'.join(mat_path.split('/')[:-1])
+    asset_name = mat_path.split('/')[-1]
+
+    mat = asset_tools.create_asset(
+        asset_name=asset_name,
+        package_path=pkg_path,
+        asset_class=unreal.Material,
+        factory=mat_factory
+    )
+
+    if not mat:
+        return None
+
+    base_color_node = unreal.MaterialEditingLibrary.create_material_expression(
+        mat, unreal.MaterialExpressionVectorParameter, -400, 0
+    )
+    base_color_node.set_editor_property("parameter_name", "BaseColor")
+    base_color_node.set_editor_property("default_value", unreal.LinearColor(1.0, 1.0, 1.0, 1.0))
+
+    roughness_node = unreal.MaterialEditingLibrary.create_material_expression(
+        mat, unreal.MaterialExpressionScalarParameter, -400, 200
+    )
+    roughness_node.set_editor_property("parameter_name", "Roughness")
+    roughness_node.set_editor_property("default_value", 0.5)
+
+    noise_node = unreal.MaterialEditingLibrary.create_material_expression(
+        mat, unreal.MaterialExpressionNoise, -400, -200
+    )
+    noise_node.set_editor_property("scale", 0.1)
+
+    multiply_node = unreal.MaterialEditingLibrary.create_material_expression(
+        mat, unreal.MaterialExpressionMultiply, -200, 0
+    )
+
+    unreal.MaterialEditingLibrary.connect_material_expressions(
+        base_color_node, "", multiply_node, "A"
+    )
+    unreal.MaterialEditingLibrary.connect_material_expressions(
+        noise_node, "", multiply_node, "B"
+    )
+
+    unreal.MaterialEditingLibrary.connect_material_property(
+        multiply_node, "", unreal.MaterialProperty.MP_BASE_COLOR
+    )
+    unreal.MaterialEditingLibrary.connect_material_property(
+        roughness_node, "", unreal.MaterialProperty.MP_ROUGHNESS
+    )
+
+    unreal.MaterialEditingLibrary.recompile_material(mat)
+    return mat
+
+def create_material_instance(mat_inst_path, parent_mat, color, roughness):
+    if unreal.EditorAssetLibrary.does_asset_exist(mat_inst_path):
+        mat_inst = unreal.EditorAssetLibrary.load_asset(mat_inst_path)
+    else:
+        mat_inst_factory = unreal.MaterialInstanceConstantFactoryNew()
+        asset_tools = unreal.AssetToolsHelpers.get_asset_tools()
+
+        pkg_path = '/'.join(mat_inst_path.split('/')[:-1])
+        asset_name = mat_inst_path.split('/')[-1]
+
+        mat_inst = asset_tools.create_asset(
+            asset_name=asset_name,
+            package_path=pkg_path,
+            asset_class=unreal.MaterialInstanceConstant,
+            factory=mat_inst_factory
+        )
+
+        if mat_inst and parent_mat:
+            unreal.MaterialEditingLibrary.set_material_instance_parent(mat_inst, parent_mat)
+
+    if mat_inst:
+        unreal.MaterialEditingLibrary.set_material_instance_vector_parameter_value(
+            mat_inst, "BaseColor", unreal.LinearColor(color[0], color[1], color[2], color[3])
+        )
+        unreal.MaterialEditingLibrary.set_material_instance_scalar_parameter_value(
+            mat_inst, "Roughness", roughness
+        )
+        unreal.MaterialEditingLibrary.update_material_instance(mat_inst)
+
+    return mat_inst
+
+def assign_material_to_mesh(static_mesh, material_instance):
+    if not static_mesh or not material_instance:
+        return
+
+    materials = static_mesh.get_editor_property('static_materials')
+
+    if not materials or len(materials) == 0:
+        new_mat = unreal.StaticMaterial()
+        new_mat.material_interface = material_instance
+        materials = [new_mat]
+    else:
+        materials[0].material_interface = material_instance
+
+    static_mesh.set_editor_property('static_materials', materials)
+
+def generate_pine_tree(mesh_path, mat_inst):
+    if unreal.EditorAssetLibrary.does_asset_exist(mesh_path):
+        print(f"Asset already exists: {mesh_path}")
+        return
+
+    try:
+        dyn_mesh = unreal.GeometryScriptLibrary_CreateNewDynamicMesh.create_new_dynamic_mesh()
+    except AttributeError:
+        try:
+            dyn_mesh = unreal.GeometryScript_AssetUtils.create_new_dynamic_mesh()
+        except AttributeError:
+            dyn_mesh = unreal.DynamicMesh()
+
+    options = unreal.GeometryScriptPrimitiveOptions()
+    transform = unreal.Transform()
+
+    try:
+        if hasattr(unreal, "GeometryScriptLibrary_MeshPrimitiveFunctions"):
+            unreal.GeometryScriptLibrary_MeshPrimitiveFunctions.append_cylinder(
+                target_mesh=dyn_mesh,
+                primitive_options=options,
+                transform=transform,
+                radius=15.0,
+                height=150.0,
+                radial_steps=6,
+                height_steps=1,
+                capped=True,
+                origin=unreal.GeometryScriptPrimitiveOriginMode.BASE
+            )
+
+            leaf_transform = unreal.Transform()
+            leaf_transform.translation = [0, 0, 80.0]
+            unreal.GeometryScriptLibrary_MeshPrimitiveFunctions.append_cone(
+                target_mesh=dyn_mesh,
+                primitive_options=options,
+                transform=leaf_transform,
+                base_radius=60.0,
+                top_radius=0.0,
+                height=150.0,
+                radial_steps=6,
+                height_steps=1,
+                capped=True,
+                origin=unreal.GeometryScriptPrimitiveOriginMode.BASE
+            )
+
+            leaf_transform.translation = [0, 0, 140.0]
+            unreal.GeometryScriptLibrary_MeshPrimitiveFunctions.append_cone(
+                target_mesh=dyn_mesh,
+                primitive_options=options,
+                transform=leaf_transform,
+                base_radius=50.0,
+                top_radius=0.0,
+                height=120.0,
+                radial_steps=6,
+                height_steps=1,
+                capped=True,
+                origin=unreal.GeometryScriptPrimitiveOriginMode.BASE
+            )
+
+            leaf_transform.translation = [0, 0, 190.0]
+            unreal.GeometryScriptLibrary_MeshPrimitiveFunctions.append_cone(
+                target_mesh=dyn_mesh,
+                primitive_options=options,
+                transform=leaf_transform,
+                base_radius=35.0,
+                top_radius=0.0,
+                height=100.0,
+                radial_steps=6,
+                height_steps=1,
+                capped=True,
+                origin=unreal.GeometryScriptPrimitiveOriginMode.BASE
+            )
+        else:
+            unreal.GeometryScript_MeshPrimitiveFunctions.append_cylinder(
+                target_mesh=dyn_mesh,
+                primitive_options=options,
+                transform=transform,
+                radius=15.0,
+                height=150.0,
+                radial_steps=6,
+                height_steps=1,
+                capped=True,
+                origin=unreal.GeometryScriptPrimitiveOriginMode.BASE
+            )
+
+            leaf_transform = unreal.Transform()
+            leaf_transform.translation = [0, 0, 80.0]
+            unreal.GeometryScript_MeshPrimitiveFunctions.append_cone(
+                target_mesh=dyn_mesh,
+                primitive_options=options,
+                transform=leaf_transform,
+                base_radius=60.0,
+                top_radius=0.0,
+                height=150.0,
+                radial_steps=6,
+                height_steps=1,
+                capped=True,
+                origin=unreal.GeometryScriptPrimitiveOriginMode.BASE
+            )
+
+            leaf_transform.translation = [0, 0, 140.0]
+            unreal.GeometryScript_MeshPrimitiveFunctions.append_cone(
+                target_mesh=dyn_mesh,
+                primitive_options=options,
+                transform=leaf_transform,
+                base_radius=50.0,
+                top_radius=0.0,
+                height=120.0,
+                radial_steps=6,
+                height_steps=1,
+                capped=True,
+                origin=unreal.GeometryScriptPrimitiveOriginMode.BASE
+            )
+
+            leaf_transform.translation = [0, 0, 190.0]
+            unreal.GeometryScript_MeshPrimitiveFunctions.append_cone(
+                target_mesh=dyn_mesh,
+                primitive_options=options,
+                transform=leaf_transform,
+                base_radius=35.0,
+                top_radius=0.0,
+                height=100.0,
+                radial_steps=6,
+                height_steps=1,
+                capped=True,
+                origin=unreal.GeometryScriptPrimitiveOriginMode.BASE
+            )
+    except Exception as e:
+        print(f"GeometryScript generation failed: {e}")
+        return
+
+    create_options = unreal.GeometryScriptCreateNewStaticMeshAssetOptions()
+    try:
+        if hasattr(unreal, "GeometryScriptLibrary_CreateNewStaticMeshAssetFromDynamicMesh"):
+            static_mesh = unreal.GeometryScriptLibrary_CreateNewStaticMeshAssetFromDynamicMesh.create_new_static_mesh_asset_from_dynamic_mesh(
+                dynamic_mesh=dyn_mesh,
+                asset_path_and_name=mesh_path,
+                options=create_options
+            )
+        else:
+            static_mesh = unreal.GeometryScript_AssetUtils.create_new_static_mesh_asset_from_dynamic_mesh(
+                dynamic_mesh=dyn_mesh,
+                asset_path_and_name=mesh_path,
+                options=create_options
+            )
+
+        assign_material_to_mesh(static_mesh, mat_inst)
+    except Exception as e:
+        print(f"GeometryScript mesh bake failed: {e}")
+
+
+def generate_forest_rock(mesh_path, mat_inst):
+    if unreal.EditorAssetLibrary.does_asset_exist(mesh_path):
+        print(f"Asset already exists: {mesh_path}")
+        return
+
+    try:
+        dyn_mesh = unreal.GeometryScriptLibrary_CreateNewDynamicMesh.create_new_dynamic_mesh()
+    except AttributeError:
+        try:
+            dyn_mesh = unreal.GeometryScript_AssetUtils.create_new_dynamic_mesh()
+        except AttributeError:
+            dyn_mesh = unreal.DynamicMesh()
+
+    options = unreal.GeometryScriptPrimitiveOptions()
+    transform = unreal.Transform()
+
+    try:
+        if hasattr(unreal, "GeometryScriptLibrary_MeshPrimitiveFunctions"):
+            unreal.GeometryScriptLibrary_MeshPrimitiveFunctions.append_box(
+                target_mesh=dyn_mesh,
+                primitive_options=options,
+                transform=transform,
+                dimension_x=120.0,
+                dimension_y=100.0,
+                dimension_z=50.0,
+                steps_x=3,
+                steps_y=3,
+                steps_z=3,
+                origin=unreal.GeometryScriptPrimitiveOriginMode.BASE
+            )
+        else:
+            unreal.GeometryScript_MeshPrimitiveFunctions.append_box(
+                target_mesh=dyn_mesh,
+                primitive_options=options,
+                transform=transform,
+                dimension_x=120.0,
+                dimension_y=100.0,
+                dimension_z=50.0,
+                steps_x=3,
+                steps_y=3,
+                steps_z=3,
+                origin=unreal.GeometryScriptPrimitiveOriginMode.BASE
+            )
+    except Exception as e:
+        print(f"GeometryScript generation failed: {e}")
+        return
+
+    create_options = unreal.GeometryScriptCreateNewStaticMeshAssetOptions()
+    try:
+        if hasattr(unreal, "GeometryScriptLibrary_CreateNewStaticMeshAssetFromDynamicMesh"):
+            static_mesh = unreal.GeometryScriptLibrary_CreateNewStaticMeshAssetFromDynamicMesh.create_new_static_mesh_asset_from_dynamic_mesh(
+                dynamic_mesh=dyn_mesh,
+                asset_path_and_name=mesh_path,
+                options=create_options
+            )
+        else:
+            static_mesh = unreal.GeometryScript_AssetUtils.create_new_static_mesh_asset_from_dynamic_mesh(
+                dynamic_mesh=dyn_mesh,
+                asset_path_and_name=mesh_path,
+                options=create_options
+            )
+
+        assign_material_to_mesh(static_mesh, mat_inst)
+    except Exception as e:
+        print(f"GeometryScript bake failed: {e}")
+
+
+def main():
+    base_dir = '/Game/Art/Models/Forest'
+    mat_dir = '/Game/Art/Materials'
+
+    ensure_directory(base_dir)
+    ensure_directory(mat_dir)
+
+    master_mat_path = f"{mat_dir}/M_StylizedForest"
+    master_mat = create_master_material(master_mat_path)
+
+    pine_mat_path = f"{mat_dir}/MI_PineTree"
+    pine_mat = create_material_instance(pine_mat_path, master_mat, [0.05, 0.25, 0.05, 1.0], 0.8)
+
+    rock_mat_path = f"{mat_dir}/MI_ForestRock"
+    rock_mat = create_material_instance(rock_mat_path, master_mat, [0.35, 0.35, 0.32, 1.0], 0.9)
+
+    pine_mesh_path = f"{base_dir}/SM_PineTree"
+    generate_pine_tree(pine_mesh_path, pine_mat)
+
+    rock_mesh_path = f"{base_dir}/SM_ForestRock"
+    generate_forest_rock(rock_mesh_path, rock_mat)
+
+    print("Asset generation for Forest biome complete.")
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This PR introduces programmatic 3D asset generation and integration for the **Forest Biome**.

### Changes
*   **Asset Generation:** Added a new Python script (`generate_forest_assets.py`) to generate two 3D meshes using UE5 Geometry Scripting: `SM_PineTree` and `SM_ForestRock`.
*   **Material Generation:** The Python script constructs a stylized master material (`M_StylizedForest`) and assigns two material instances (`MI_PineTree`, `MI_ForestRock`) to the generated meshes.
*   **PCG Integration:** Added the `UForestPCGSettings` class to `Source/BikeAdventure/Systems/AdvancedBiomePCGSettings` files to procedural scatter the generated trees and rocks within the Forest biome. Lowered `TreeDensity` to `0.4f` and radial steps to `6` to uphold the strict 60 FPS performance budget.
*   **Documentation:** Updated the project documentation (`docs/ART_PIPELINE.md`) with instructions on running the new script.

All automated tests and Gauntlet tests pass, respecting memory and FPS budgets.

---
*PR created automatically by Jules for task [13093017401897158119](https://jules.google.com/task/13093017401897158119) started by @zvirb*