### PR TITLE
feat: Add generated procedural crop and animal models to Countryside biome

### DIFF
--- a/Source/BikeAdventure/Systems/AdvancedBiomePCGSettings.cpp
+++ b/Source/BikeAdventure/Systems/AdvancedBiomePCGSettings.cpp
@@ -56,6 +56,8 @@ UCountrysidePCGSettings::UCountrysidePCGSettings()
     // Add programmatic assets to arrays
     FarmBuildingMeshes.Add(TSoftObjectPtr<UStaticMesh>(FSoftObjectPath(TEXT("/Game/Art/Models/Countryside/SM_FarmHouse.SM_FarmHouse"))));
     FenceMeshes.Add(TSoftObjectPtr<UStaticMesh>(FSoftObjectPath(TEXT("/Game/Art/Models/Countryside/SM_CountrysideFence.SM_CountrysideFence"))));
+    CropMeshes.Add(TSoftObjectPtr<UStaticMesh>(FSoftObjectPath(TEXT("/Game/Art/Models/Countryside/SM_Crop.SM_Crop"))));
+    AnimalMeshes.Add(TSoftObjectPtr<UStaticMesh>(FSoftObjectPath(TEXT("/Game/Art/Models/Countryside/SM_Animal.SM_Animal"))));
 }
 
 // Mountain PCG Settings

--- a/docs/ART_PIPELINE.md
+++ b/docs/ART_PIPELINE.md
@@ -37,7 +37,7 @@ As part of the goal to dynamically generate content, there are Python scripts in
 
 The scripts will:
 - Create `/Game/Art/Models/Forest/`, `/Game/Art/Models/Mountains/`, `/Game/Art/Models/Urban/`, `/Game/Art/Models/Countryside/`, `/Game/Art/Models/Desert/`, `/Game/Art/Models/Beach/`, `/Game/Art/Models/Character/`, and `/Game/Art/Materials/`.
-- Procedurally generate `SM_PineTree` and `SM_ForestRock` for Forest, `SM_MountainRock` and `SM_AlpinePlant` for Mountains, `SM_UrbanBuilding` and `SM_UrbanBench` for Urban, `SM_PalmTree` and `SM_Sandcastle` for Beach, and `SM_Bike` for the Main Bike Character using simple primitive and geometry boolean/noise functions.
+- Procedurally generate `SM_PineTree` and `SM_ForestRock` for Forest, `SM_MountainRock` and `SM_AlpinePlant` for Mountains, `SM_UrbanBuilding` and `SM_UrbanBench` for Urban, `SM_PalmTree` and `SM_Sandcastle` for Beach, `SM_FarmHouse`, `SM_CountrysideFence`, `SM_Crop`, and `SM_Animal` for Countryside, and `SM_Bike` for the Main Bike Character using simple primitive and geometry boolean/noise functions.
 - Procedurally construct master materials like `M_StylizedMaster` and `M_StylizedUrban`, and derived material instances (e.g., `MI_MountainRock`, `MI_UrbanBuilding`).
 - Assign these material instances to the corresponding static meshes.
 

--- a/scripts/asset_generation/generate_countryside_assets.py
+++ b/scripts/asset_generation/generate_countryside_assets.py
@@ -384,6 +384,203 @@ def generate_countryside_fence(mesh_path, mat_inst):
     except Exception as e:
         print(f"GeometryScript bake failed: {e}")
 
+
+def generate_countryside_crop(mesh_path, mat_inst):
+    if unreal.EditorAssetLibrary.does_asset_exist(mesh_path):
+        print(f"Asset already exists: {mesh_path}")
+        return
+
+    try:
+        dyn_mesh = unreal.GeometryScriptLibrary_CreateNewDynamicMesh.create_new_dynamic_mesh()
+    except AttributeError:
+        try:
+            dyn_mesh = unreal.GeometryScript_AssetUtils.create_new_dynamic_mesh()
+        except AttributeError:
+            dyn_mesh = unreal.DynamicMesh()
+
+    options = unreal.GeometryScriptPrimitiveOptions()
+
+    try:
+        if hasattr(unreal, "GeometryScriptLibrary_MeshPrimitiveFunctions"):
+            # A simple wheat stalk / crop (cylinder)
+            stalk_transform = unreal.Transform()
+            unreal.GeometryScriptLibrary_MeshPrimitiveFunctions.append_cylinder(
+                target_mesh=dyn_mesh,
+                primitive_options=options,
+                transform=stalk_transform,
+                radius=5.0,
+                height=60.0,
+                radial_steps=6,
+                height_steps=1,
+                capped=True,
+                origin=unreal.GeometryScriptPrimitiveOriginMode.BASE
+            )
+            # Add a small top for the crop
+            top_transform = unreal.Transform()
+            top_transform.translation = [0, 0, 50.0]
+            unreal.GeometryScriptLibrary_MeshPrimitiveFunctions.append_cone(
+                target_mesh=dyn_mesh,
+                primitive_options=options,
+                transform=top_transform,
+                base_radius=10.0,
+                top_radius=0.0,
+                height=20.0,
+                radial_steps=6,
+                height_steps=1,
+                capped=True,
+                origin=unreal.GeometryScriptPrimitiveOriginMode.BASE
+            )
+        else:
+            stalk_transform = unreal.Transform()
+            unreal.GeometryScript_MeshPrimitiveFunctions.append_cylinder(
+                target_mesh=dyn_mesh,
+                primitive_options=options,
+                transform=stalk_transform,
+                radius=5.0,
+                height=60.0,
+                radial_steps=6,
+                height_steps=1,
+                capped=True,
+                origin=unreal.GeometryScriptPrimitiveOriginMode.BASE
+            )
+            top_transform = unreal.Transform()
+            top_transform.translation = [0, 0, 50.0]
+            unreal.GeometryScript_MeshPrimitiveFunctions.append_cone(
+                target_mesh=dyn_mesh,
+                primitive_options=options,
+                transform=top_transform,
+                base_radius=10.0,
+                top_radius=0.0,
+                height=20.0,
+                radial_steps=6,
+                height_steps=1,
+                capped=True,
+                origin=unreal.GeometryScriptPrimitiveOriginMode.BASE
+            )
+    except Exception as e:
+        print(f"GeometryScript generation failed: {e}")
+        return
+
+    create_options = unreal.GeometryScriptCreateNewStaticMeshAssetOptions()
+    try:
+        if hasattr(unreal, "GeometryScriptLibrary_CreateNewStaticMeshAssetFromDynamicMesh"):
+            static_mesh = unreal.GeometryScriptLibrary_CreateNewStaticMeshAssetFromDynamicMesh.create_new_static_mesh_asset_from_dynamic_mesh(
+                dynamic_mesh=dyn_mesh,
+                asset_path_and_name=mesh_path,
+                options=create_options
+            )
+        else:
+            static_mesh = unreal.GeometryScript_AssetUtils.create_new_static_mesh_asset_from_dynamic_mesh(
+                dynamic_mesh=dyn_mesh,
+                asset_path_and_name=mesh_path,
+                options=create_options
+            )
+
+        # Apply material
+        assign_material_to_mesh(static_mesh, mat_inst)
+    except Exception as e:
+        print(f"GeometryScript bake failed: {e}")
+
+def generate_countryside_animal(mesh_path, mat_inst):
+    if unreal.EditorAssetLibrary.does_asset_exist(mesh_path):
+        print(f"Asset already exists: {mesh_path}")
+        return
+
+    try:
+        dyn_mesh = unreal.GeometryScriptLibrary_CreateNewDynamicMesh.create_new_dynamic_mesh()
+    except AttributeError:
+        try:
+            dyn_mesh = unreal.GeometryScript_AssetUtils.create_new_dynamic_mesh()
+        except AttributeError:
+            dyn_mesh = unreal.DynamicMesh()
+
+    options = unreal.GeometryScriptPrimitiveOptions()
+
+    try:
+        if hasattr(unreal, "GeometryScriptLibrary_MeshPrimitiveFunctions"):
+            # Body
+            body_transform = unreal.Transform()
+            body_transform.translation = [0, 0, 40.0]
+            unreal.GeometryScriptLibrary_MeshPrimitiveFunctions.append_box(
+                target_mesh=dyn_mesh,
+                primitive_options=options,
+                transform=body_transform,
+                dimension_x=80.0,
+                dimension_y=50.0,
+                dimension_z=50.0,
+                steps_x=1,
+                steps_y=1,
+                steps_z=1,
+                origin=unreal.GeometryScriptPrimitiveOriginMode.CENTER
+            )
+            # Head
+            head_transform = unreal.Transform()
+            head_transform.translation = [50.0, 0, 60.0]
+            unreal.GeometryScriptLibrary_MeshPrimitiveFunctions.append_box(
+                target_mesh=dyn_mesh,
+                primitive_options=options,
+                transform=head_transform,
+                dimension_x=30.0,
+                dimension_y=25.0,
+                dimension_z=30.0,
+                steps_x=1,
+                steps_y=1,
+                steps_z=1,
+                origin=unreal.GeometryScriptPrimitiveOriginMode.CENTER
+            )
+        else:
+            body_transform = unreal.Transform()
+            body_transform.translation = [0, 0, 40.0]
+            unreal.GeometryScript_MeshPrimitiveFunctions.append_box(
+                target_mesh=dyn_mesh,
+                primitive_options=options,
+                transform=body_transform,
+                dimension_x=80.0,
+                dimension_y=50.0,
+                dimension_z=50.0,
+                steps_x=1,
+                steps_y=1,
+                steps_z=1,
+                origin=unreal.GeometryScriptPrimitiveOriginMode.CENTER
+            )
+            head_transform = unreal.Transform()
+            head_transform.translation = [50.0, 0, 60.0]
+            unreal.GeometryScript_MeshPrimitiveFunctions.append_box(
+                target_mesh=dyn_mesh,
+                primitive_options=options,
+                transform=head_transform,
+                dimension_x=30.0,
+                dimension_y=25.0,
+                dimension_z=30.0,
+                steps_x=1,
+                steps_y=1,
+                steps_z=1,
+                origin=unreal.GeometryScriptPrimitiveOriginMode.CENTER
+            )
+    except Exception as e:
+        print(f"GeometryScript generation failed: {e}")
+        return
+
+    create_options = unreal.GeometryScriptCreateNewStaticMeshAssetOptions()
+    try:
+        if hasattr(unreal, "GeometryScriptLibrary_CreateNewStaticMeshAssetFromDynamicMesh"):
+            static_mesh = unreal.GeometryScriptLibrary_CreateNewStaticMeshAssetFromDynamicMesh.create_new_static_mesh_asset_from_dynamic_mesh(
+                dynamic_mesh=dyn_mesh,
+                asset_path_and_name=mesh_path,
+                options=create_options
+            )
+        else:
+            static_mesh = unreal.GeometryScript_AssetUtils.create_new_static_mesh_asset_from_dynamic_mesh(
+                dynamic_mesh=dyn_mesh,
+                asset_path_and_name=mesh_path,
+                options=create_options
+            )
+
+        # Apply material
+        assign_material_to_mesh(static_mesh, mat_inst)
+    except Exception as e:
+        print(f"GeometryScript bake failed: {e}")
+
 def main():
     base_dir = '/Game/Art/Models/Countryside'
     mat_dir = '/Game/Art/Materials'
@@ -402,12 +599,24 @@ def main():
     fence_mat_path = f"{mat_dir}/MI_CountrysideFence"
     fence_mat = create_material_instance(fence_mat_path, master_mat, [0.4, 0.2, 0.1, 1.0], 0.9) # Brown wood color
 
+    crop_mat_path = f"{mat_dir}/MI_CountrysideCrop"
+    crop_mat = create_material_instance(crop_mat_path, master_mat, [0.7, 0.8, 0.2, 1.0], 0.6) # Yellow/Green
+
+    animal_mat_path = f"{mat_dir}/MI_CountrysideAnimal"
+    animal_mat = create_material_instance(animal_mat_path, master_mat, [0.85, 0.85, 0.85, 1.0], 0.8) # White/Gray
+
     # Programmatic 3D Modeling
     house_mesh_path = f"{base_dir}/SM_FarmHouse"
     generate_farm_house(house_mesh_path, house_mat)
 
     fence_mesh_path = f"{base_dir}/SM_CountrysideFence"
     generate_countryside_fence(fence_mesh_path, fence_mat)
+
+    crop_mesh_path = f"{base_dir}/SM_Crop"
+    generate_countryside_crop(crop_mesh_path, crop_mat)
+
+    animal_mesh_path = f"{base_dir}/SM_Animal"
+    generate_countryside_animal(animal_mesh_path, animal_mat)
 
     print("Asset generation for Countryside biome complete.")
 


### PR DESCRIPTION
This PR introduces missing 3D models and procedural assets for the Countryside biome. The changes rely on UE5 Python scripts to dynamically generate simple stylized meshes (like crops and animals) directly via Unreal's Geometry Scripting API without uploading binary assets. The generated assets are then automatically linked into the Countryside PCG configuration for in-game scattering.

---
*PR created automatically by Jules for task [10937307055779104776](https://jules.google.com/task/10937307055779104776) started by @zvirb*