### PR TITLE
Add procedural bridge generation and integration for Wetlands biome

### DIFF
--- a/Source/BikeAdventure/Systems/AdvancedBiomePCGSettings.cpp
+++ b/Source/BikeAdventure/Systems/AdvancedBiomePCGSettings.cpp
@@ -103,6 +103,7 @@ UWetlandsPCGSettings::UWetlandsPCGSettings()
     // Add programmatic assets to arrays
     WaterSurfaceMeshes.Add(TSoftObjectPtr<UStaticMesh>(FSoftObjectPath(TEXT("/Game/Art/Models/Wetlands/SM_WaterBody.SM_WaterBody"))));
     MarshPlantMeshes.Add(TSoftObjectPtr<UStaticMesh>(FSoftObjectPath(TEXT("/Game/Art/Models/Wetlands/SM_MarshPlant.SM_MarshPlant"))));
+    BridgeMeshes.Add(TSoftObjectPtr<UStaticMesh>(FSoftObjectPath(TEXT("/Game/Art/Models/Wetlands/SM_WetlandsBridge.SM_WetlandsBridge"))));
 }
 
 // Advanced Biome Generation Element Implementation

--- a/docs/ART_PIPELINE.md
+++ b/docs/ART_PIPELINE.md
@@ -36,8 +36,8 @@ As part of the goal to dynamically generate content, there are Python scripts in
 ### Asset Outputs
 
 The scripts will:
-- Create `/Game/Art/Models/Forest/`, `/Game/Art/Models/Mountains/`, `/Game/Art/Models/Urban/`, `/Game/Art/Models/Countryside/`, `/Game/Art/Models/Desert/`, `/Game/Art/Models/Beach/`, `/Game/Art/Models/Character/`, and `/Game/Art/Materials/`.
-- Procedurally generate `SM_PineTree` and `SM_ForestRock` for Forest, `SM_MountainRock` and `SM_AlpinePlant` for Mountains, `SM_UrbanBuilding` and `SM_UrbanBench` for Urban, `SM_PalmTree` and `SM_Sandcastle` for Beach, `SM_FarmHouse`, `SM_CountrysideFence`, `SM_Crop`, and `SM_Animal` for Countryside, and `SM_Bike` for the Main Bike Character using simple primitive and geometry boolean/noise functions.
+- Create `/Game/Art/Models/Forest/`, `/Game/Art/Models/Mountains/`, `/Game/Art/Models/Urban/`, `/Game/Art/Models/Countryside/`, `/Game/Art/Models/Desert/`, `/Game/Art/Models/Beach/`, `/Game/Art/Models/Wetlands/`, `/Game/Art/Models/Character/`, and `/Game/Art/Materials/`.
+- Procedurally generate `SM_PineTree` and `SM_ForestRock` for Forest, `SM_MountainRock` and `SM_AlpinePlant` for Mountains, `SM_UrbanBuilding` and `SM_UrbanBench` for Urban, `SM_PalmTree` and `SM_Sandcastle` for Beach, `SM_FarmHouse`, `SM_CountrysideFence`, `SM_Crop`, and `SM_Animal` for Countryside, `SM_WaterBody`, `SM_MarshPlant`, and `SM_WetlandsBridge` for Wetlands, and `SM_Bike` for the Main Bike Character using simple primitive and geometry boolean/noise functions.
 - Procedurally construct master materials like `M_StylizedMaster` and `M_StylizedUrban`, and derived material instances (e.g., `MI_MountainRock`, `MI_UrbanBuilding`).
 - Assign these material instances to the corresponding static meshes.
 

--- a/scripts/asset_generation/generate_wetlands_assets.py
+++ b/scripts/asset_generation/generate_wetlands_assets.py
@@ -186,6 +186,142 @@ def generate_water_body(mesh_path, mat_inst):
     except Exception as e:
         print(f"GeometryScript bake failed: {e}")
 
+def generate_wetlands_bridge(mesh_path, mat_inst):
+    if unreal.EditorAssetLibrary.does_asset_exist(mesh_path):
+        print(f"Asset already exists: {mesh_path}")
+        return
+
+    try:
+        dyn_mesh = unreal.GeometryScriptLibrary_CreateNewDynamicMesh.create_new_dynamic_mesh()
+    except AttributeError:
+        try:
+            dyn_mesh = unreal.GeometryScript_AssetUtils.create_new_dynamic_mesh()
+        except AttributeError:
+            dyn_mesh = unreal.DynamicMesh()
+
+    options = unreal.GeometryScriptPrimitiveOptions()
+
+    try:
+        if hasattr(unreal, "GeometryScriptLibrary_MeshPrimitiveFunctions"):
+            # Main walkway
+            walkway_transform = unreal.Transform()
+            walkway_transform.translation = [0.0, 0.0, 10.0]
+            unreal.GeometryScriptLibrary_MeshPrimitiveFunctions.append_box(
+                target_mesh=dyn_mesh,
+                primitive_options=options,
+                transform=walkway_transform,
+                dimension_x=400.0,
+                dimension_y=100.0,
+                dimension_z=10.0,
+                steps_x=1,
+                steps_y=1,
+                steps_z=1,
+                origin=unreal.GeometryScriptPrimitiveOriginMode.CENTER
+            )
+
+            # Left rail
+            left_rail_transform = unreal.Transform()
+            left_rail_transform.translation = [0.0, -45.0, 30.0]
+            unreal.GeometryScriptLibrary_MeshPrimitiveFunctions.append_box(
+                target_mesh=dyn_mesh,
+                primitive_options=options,
+                transform=left_rail_transform,
+                dimension_x=400.0,
+                dimension_y=5.0,
+                dimension_z=10.0,
+                steps_x=1,
+                steps_y=1,
+                steps_z=1,
+                origin=unreal.GeometryScriptPrimitiveOriginMode.CENTER
+            )
+
+            # Right rail
+            right_rail_transform = unreal.Transform()
+            right_rail_transform.translation = [0.0, 45.0, 30.0]
+            unreal.GeometryScriptLibrary_MeshPrimitiveFunctions.append_box(
+                target_mesh=dyn_mesh,
+                primitive_options=options,
+                transform=right_rail_transform,
+                dimension_x=400.0,
+                dimension_y=5.0,
+                dimension_z=10.0,
+                steps_x=1,
+                steps_y=1,
+                steps_z=1,
+                origin=unreal.GeometryScriptPrimitiveOriginMode.CENTER
+            )
+        else:
+            # Main walkway
+            walkway_transform = unreal.Transform()
+            walkway_transform.translation = [0.0, 0.0, 10.0]
+            unreal.GeometryScript_MeshPrimitiveFunctions.append_box(
+                target_mesh=dyn_mesh,
+                primitive_options=options,
+                transform=walkway_transform,
+                dimension_x=400.0,
+                dimension_y=100.0,
+                dimension_z=10.0,
+                steps_x=1,
+                steps_y=1,
+                steps_z=1,
+                origin=unreal.GeometryScriptPrimitiveOriginMode.CENTER
+            )
+
+            # Left rail
+            left_rail_transform = unreal.Transform()
+            left_rail_transform.translation = [0.0, -45.0, 30.0]
+            unreal.GeometryScript_MeshPrimitiveFunctions.append_box(
+                target_mesh=dyn_mesh,
+                primitive_options=options,
+                transform=left_rail_transform,
+                dimension_x=400.0,
+                dimension_y=5.0,
+                dimension_z=10.0,
+                steps_x=1,
+                steps_y=1,
+                steps_z=1,
+                origin=unreal.GeometryScriptPrimitiveOriginMode.CENTER
+            )
+
+            # Right rail
+            right_rail_transform = unreal.Transform()
+            right_rail_transform.translation = [0.0, 45.0, 30.0]
+            unreal.GeometryScript_MeshPrimitiveFunctions.append_box(
+                target_mesh=dyn_mesh,
+                primitive_options=options,
+                transform=right_rail_transform,
+                dimension_x=400.0,
+                dimension_y=5.0,
+                dimension_z=10.0,
+                steps_x=1,
+                steps_y=1,
+                steps_z=1,
+                origin=unreal.GeometryScriptPrimitiveOriginMode.CENTER
+            )
+    except Exception as e:
+        print(f"GeometryScript generation failed: {e}")
+        return
+
+    create_options = unreal.GeometryScriptCreateNewStaticMeshAssetOptions()
+    try:
+        if hasattr(unreal, "GeometryScriptLibrary_CreateNewStaticMeshAssetFromDynamicMesh"):
+            static_mesh = unreal.GeometryScriptLibrary_CreateNewStaticMeshAssetFromDynamicMesh.create_new_static_mesh_asset_from_dynamic_mesh(
+                dynamic_mesh=dyn_mesh,
+                asset_path_and_name=mesh_path,
+                options=create_options
+            )
+        else:
+            static_mesh = unreal.GeometryScript_AssetUtils.create_new_static_mesh_asset_from_dynamic_mesh(
+                dynamic_mesh=dyn_mesh,
+                asset_path_and_name=mesh_path,
+                options=create_options
+            )
+
+        # Apply material
+        assign_material_to_mesh(static_mesh, mat_inst)
+    except Exception as e:
+        print(f"GeometryScript bake failed: {e}")
+
 def generate_marsh_plant(mesh_path, mat_inst):
     if unreal.EditorAssetLibrary.does_asset_exist(mesh_path):
         print(f"Asset already exists: {mesh_path}")
@@ -309,6 +445,12 @@ def main():
 
     plant_mesh_path = f"{base_dir}/SM_MarshPlant"
     generate_marsh_plant(plant_mesh_path, plant_mat)
+
+    bridge_mat_path = f"{mat_dir}/MI_WetlandsBridge"
+    bridge_mat = create_material_instance(bridge_mat_path, master_mat, [0.3, 0.2, 0.1, 1.0], 0.8) # Brown, rough wood
+
+    bridge_mesh_path = f"{base_dir}/SM_WetlandsBridge"
+    generate_wetlands_bridge(bridge_mesh_path, bridge_mat)
 
     print("Asset generation for Wetlands biome complete.")
 


### PR DESCRIPTION
This PR focuses on incrementally generating missing 3D models and materials for the "BikeAdventure" project, specifically targeting the Wetlands biome.

### Modifications
- **Python Generator:** Updated `generate_wetlands_assets.py` to include a new generator function, `generate_wetlands_bridge`, which uses primitive geometry operations (boxes) to assemble a simple bridge structure (walkway and side rails). It also applies a newly created stylized brown material instance.
- **C++ PCG Integration:** Added the programmatic asset reference for `SM_WetlandsBridge` to the `BridgeMeshes` array within the `UWetlandsPCGSettings` constructor.
- **Documentation:** Updated the `docs/ART_PIPELINE.md` file to reflect the new Wetlands assets (WaterBody, MarshPlant, and WetlandsBridge).

### Constraints
The generation respects the procedural rules by checking if the asset exists before overwriting and strictly uses editor scripts as required. Tests have been run confirming no compile or execution regressions.

---
*PR created automatically by Jules for task [14950754420428003903](https://jules.google.com/task/14950754420428003903) started by @zvirb*