### PR TITLE
feat: Programmatic Generation and PCG Integration of Mountain Cliff Asset

### DIFF
--- a/Source/BikeAdventure/Systems/AdvancedBiomePCGSettings.cpp
+++ b/Source/BikeAdventure/Systems/AdvancedBiomePCGSettings.cpp
@@ -74,6 +74,7 @@ UMountainPCGSettings::UMountainPCGSettings()
     // Add programmatic assets to arrays
     RockMeshes.Add(TSoftObjectPtr<UStaticMesh>(FSoftObjectPath(TEXT("/Game/Art/Models/Mountains/SM_MountainRock.SM_MountainRock"))));
     AlpinePlantMeshes.Add(TSoftObjectPtr<UStaticMesh>(FSoftObjectPath(TEXT("/Game/Art/Models/Mountains/SM_AlpinePlant.SM_AlpinePlant"))));
+    CliffMeshes.Add(TSoftObjectPtr<UStaticMesh>(FSoftObjectPath(TEXT("/Game/Art/Models/Mountains/SM_MountainCliff.SM_MountainCliff"))));
 }
 
 // Desert PCG Settings

--- a/docs/ART_PIPELINE.md
+++ b/docs/ART_PIPELINE.md
@@ -37,7 +37,7 @@ As part of the goal to dynamically generate content, there are Python scripts in
 
 The scripts will:
 - Create `/Game/Art/Models/Forest/`, `/Game/Art/Models/Mountains/`, `/Game/Art/Models/Urban/`, `/Game/Art/Models/Countryside/`, `/Game/Art/Models/Desert/`, `/Game/Art/Models/Beach/`, `/Game/Art/Models/Wetlands/`, `/Game/Art/Models/Character/`, and `/Game/Art/Materials/`.
-- Procedurally generate `SM_PineTree` and `SM_ForestRock` for Forest, `SM_MountainRock` and `SM_AlpinePlant` for Mountains, `SM_UrbanBuilding` and `SM_UrbanBench` for Urban, `SM_PalmTree` and `SM_Sandcastle` for Beach, `SM_FarmHouse`, `SM_CountrysideFence`, `SM_Crop`, and `SM_Animal` for Countryside, `SM_WaterBody`, `SM_MarshPlant`, and `SM_WetlandsBridge` for Wetlands, and `SM_Bike` for the Main Bike Character using simple primitive and geometry boolean/noise functions.
+- Procedurally generate `SM_PineTree` and `SM_ForestRock` for Forest, `SM_MountainRock`, `SM_MountainCliff`, and `SM_AlpinePlant` for Mountains, `SM_UrbanBuilding` and `SM_UrbanBench` for Urban, `SM_PalmTree` and `SM_Sandcastle` for Beach, `SM_FarmHouse`, `SM_CountrysideFence`, `SM_Crop`, and `SM_Animal` for Countryside, `SM_WaterBody`, `SM_MarshPlant`, and `SM_WetlandsBridge` for Wetlands, and `SM_Bike` for the Main Bike Character using simple primitive and geometry boolean/noise functions.
 - Procedurally construct master materials like `M_StylizedMaster` and `M_StylizedUrban`, and derived material instances (e.g., `MI_MountainRock`, `MI_UrbanBuilding`).
 - Assign these material instances to the corresponding static meshes.
 

--- a/scripts/asset_generation/generate_mountain_assets.py
+++ b/scripts/asset_generation/generate_mountain_assets.py
@@ -246,6 +246,74 @@ def generate_alpine_plant(mesh_path, mat_inst):
         print(f"GeometryScript mesh bake failed: {e}")
 
 
+def generate_mountain_cliff(mesh_path, mat_inst):
+    if unreal.EditorAssetLibrary.does_asset_exist(mesh_path):
+        print(f"Asset already exists: {mesh_path}")
+        return
+
+    try:
+        dyn_mesh = unreal.GeometryScriptLibrary_CreateNewDynamicMesh.create_new_dynamic_mesh()
+    except AttributeError:
+        try:
+            dyn_mesh = unreal.GeometryScript_AssetUtils.create_new_dynamic_mesh()
+        except AttributeError:
+            dyn_mesh = unreal.DynamicMesh()
+
+    options = unreal.GeometryScriptPrimitiveOptions()
+    transform = unreal.Transform()
+
+    try:
+        if hasattr(unreal, "GeometryScriptLibrary_MeshPrimitiveFunctions"):
+            unreal.GeometryScriptLibrary_MeshPrimitiveFunctions.append_box(
+                target_mesh=dyn_mesh,
+                primitive_options=options,
+                transform=transform,
+                dimension_x=400.0,
+                dimension_y=200.0,
+                dimension_z=500.0,
+                steps_x=3,
+                steps_y=3,
+                steps_z=3,
+                origin=unreal.GeometryScriptPrimitiveOriginMode.BASE
+            )
+        else:
+            unreal.GeometryScript_MeshPrimitiveFunctions.append_box(
+                target_mesh=dyn_mesh,
+                primitive_options=options,
+                transform=transform,
+                dimension_x=400.0,
+                dimension_y=200.0,
+                dimension_z=500.0,
+                steps_x=3,
+                steps_y=3,
+                steps_z=3,
+                origin=unreal.GeometryScriptPrimitiveOriginMode.BASE
+            )
+    except Exception as e:
+        print(f"GeometryScript generation failed: {e}")
+        return
+
+    create_options = unreal.GeometryScriptCreateNewStaticMeshAssetOptions()
+    try:
+        if hasattr(unreal, "GeometryScriptLibrary_CreateNewStaticMeshAssetFromDynamicMesh"):
+            static_mesh = unreal.GeometryScriptLibrary_CreateNewStaticMeshAssetFromDynamicMesh.create_new_static_mesh_asset_from_dynamic_mesh(
+                dynamic_mesh=dyn_mesh,
+                asset_path_and_name=mesh_path,
+                options=create_options
+            )
+        else:
+            static_mesh = unreal.GeometryScript_AssetUtils.create_new_static_mesh_asset_from_dynamic_mesh(
+                dynamic_mesh=dyn_mesh,
+                asset_path_and_name=mesh_path,
+                options=create_options
+            )
+
+        # Apply material
+        assign_material_to_mesh(static_mesh, mat_inst)
+    except Exception as e:
+        print(f"GeometryScript bake failed: {e}")
+
+
 def generate_mountain_rock(mesh_path, mat_inst):
     if unreal.EditorAssetLibrary.does_asset_exist(mesh_path):
         print(f"Asset already exists: {mesh_path}")
@@ -333,12 +401,18 @@ def main():
     rock_mat_path = f"{mat_dir}/MI_MountainRock"
     rock_mat = create_material_instance(rock_mat_path, master_mat, [0.3, 0.3, 0.3, 1.0], 0.9)
 
+    cliff_mat_path = f"{mat_dir}/MI_MountainCliff"
+    cliff_mat = create_material_instance(cliff_mat_path, master_mat, [0.4, 0.35, 0.35, 1.0], 0.9)
+
     # Programmatic 3D Modeling
     plant_mesh_path = f"{base_dir}/SM_AlpinePlant"
     generate_alpine_plant(plant_mesh_path, plant_mat)
 
     rock_mesh_path = f"{base_dir}/SM_MountainRock"
     generate_mountain_rock(rock_mesh_path, rock_mat)
+
+    cliff_mesh_path = f"{base_dir}/SM_MountainCliff"
+    generate_mountain_cliff(cliff_mesh_path, cliff_mat)
 
     print("Asset generation for Mountains biome complete.")
 


### PR DESCRIPTION
This change incrementally populates the Mountain biome with the missing Cliff assets.

**What:** 
- Added a procedural Python asset generation block in `scripts/asset_generation/generate_mountain_assets.py` that builds `SM_MountainCliff` and `MI_MountainCliff`.
- Populated the `CliffMeshes` array in `UMountainPCGSettings` (in `AdvancedBiomePCGSettings.cpp`) which previously had no asset references, linking the generated cliff into the game's procedural biome generation system.
- Updated documentation.

**Why:** 
The Mountain biome required 3D art assets mapped to the C++ procedural generation logic. The `CliffMeshes` array was empty, preventing cliffs from spawning. As requested by the constraint, we generated these through UE5 Python geometry scripts rather than binary models.

**Impact:** 
Mountain biomes will now dynamically construct and spawn stylized low-poly cliff assets without breaking memory or performance budgets.

---
*PR created automatically by Jules for task [3524216898767336392](https://jules.google.com/task/3524216898767336392) started by @zvirb*