### PR TITLE
feat(urban): add procedural traffic light asset

### DIFF
--- a/Source/BikeAdventure/Systems/AdvancedBiomePCGSettings.cpp
+++ b/Source/BikeAdventure/Systems/AdvancedBiomePCGSettings.cpp
@@ -41,6 +41,7 @@ UUrbanPCGSettings::UUrbanPCGSettings()
     // Add programmatic assets to arrays
     BuildingMeshes.Add(TSoftObjectPtr<UStaticMesh>(FSoftObjectPath(TEXT("/Game/Art/Models/Urban/SM_UrbanBuilding.SM_UrbanBuilding"))));
     StreetFurnitureMeshes.Add(TSoftObjectPtr<UStaticMesh>(FSoftObjectPath(TEXT("/Game/Art/Models/Urban/SM_UrbanBench.SM_UrbanBench"))));
+    TrafficElementMeshes.Add(TSoftObjectPtr<UStaticMesh>(FSoftObjectPath(TEXT("/Game/Art/Models/Urban/SM_UrbanTrafficLight.SM_UrbanTrafficLight"))));
 }
 
 // Countryside PCG Settings

--- a/docs/ART_PIPELINE.md
+++ b/docs/ART_PIPELINE.md
@@ -37,7 +37,7 @@ As part of the goal to dynamically generate content, there are Python scripts in
 
 The scripts will:
 - Create `/Game/Art/Models/Forest/`, `/Game/Art/Models/Mountains/`, `/Game/Art/Models/Urban/`, `/Game/Art/Models/Countryside/`, `/Game/Art/Models/Desert/`, `/Game/Art/Models/Beach/`, `/Game/Art/Models/Wetlands/`, `/Game/Art/Models/Character/`, and `/Game/Art/Materials/`.
-- Procedurally generate `SM_PineTree` and `SM_ForestRock` for Forest, `SM_MountainRock`, `SM_MountainCliff`, and `SM_AlpinePlant` for Mountains, `SM_UrbanBuilding` and `SM_UrbanBench` for Urban, `SM_PalmTree` and `SM_Sandcastle` for Beach, `SM_FarmHouse`, `SM_CountrysideFence`, `SM_Crop`, and `SM_Animal` for Countryside, `SM_WaterBody`, `SM_MarshPlant`, and `SM_WetlandsBridge` for Wetlands, and `SM_Bike` for the Main Bike Character using simple primitive and geometry boolean/noise functions.
+- Procedurally generate `SM_PineTree` and `SM_ForestRock` for Forest, `SM_MountainRock`, `SM_MountainCliff`, and `SM_AlpinePlant` for Mountains, `SM_UrbanBuilding`, `SM_UrbanBench`, and `SM_UrbanTrafficLight` for Urban, `SM_PalmTree` and `SM_Sandcastle` for Beach, `SM_FarmHouse`, `SM_CountrysideFence`, `SM_Crop`, and `SM_Animal` for Countryside, `SM_WaterBody`, `SM_MarshPlant`, and `SM_WetlandsBridge` for Wetlands, and `SM_Bike` for the Main Bike Character using simple primitive and geometry boolean/noise functions.
 - Procedurally construct master materials like `M_StylizedMaster` and `M_StylizedUrban`, and derived material instances (e.g., `MI_MountainRock`, `MI_UrbanBuilding`).
 - Assign these material instances to the corresponding static meshes.
 

--- a/scripts/asset_generation/generate_urban_assets.py
+++ b/scripts/asset_generation/generate_urban_assets.py
@@ -347,6 +347,103 @@ def generate_urban_bench(mesh_path, mat_inst):
     except Exception as e:
         print(f"GeometryScript bake failed: {e}")
 
+def generate_urban_traffic_light(mesh_path, mat_inst):
+    if unreal.EditorAssetLibrary.does_asset_exist(mesh_path):
+        print(f"Asset already exists: {mesh_path}")
+        return
+
+    try:
+        dyn_mesh = unreal.GeometryScriptLibrary_CreateNewDynamicMesh.create_new_dynamic_mesh()
+    except AttributeError:
+        try:
+            dyn_mesh = unreal.GeometryScript_AssetUtils.create_new_dynamic_mesh()
+        except AttributeError:
+            dyn_mesh = unreal.DynamicMesh()
+
+    options = unreal.GeometryScriptPrimitiveOptions()
+
+    try:
+        # Post
+        post_transform = unreal.Transform()
+        post_transform.translation = [0.0, 0.0, 150.0]
+        if hasattr(unreal, "GeometryScriptLibrary_MeshPrimitiveFunctions"):
+            unreal.GeometryScriptLibrary_MeshPrimitiveFunctions.append_cylinder(
+                target_mesh=dyn_mesh,
+                primitive_options=options,
+                transform=post_transform,
+                radius=10.0,
+                height=300.0,
+                radial_steps=8,
+                height_steps=1,
+                capped=True,
+                origin=unreal.GeometryScriptPrimitiveOriginMode.CENTER
+            )
+            # Box head
+            head_transform = unreal.Transform()
+            head_transform.translation = [15.0, 0.0, 260.0]
+            unreal.GeometryScriptLibrary_MeshPrimitiveFunctions.append_box(
+                target_mesh=dyn_mesh,
+                primitive_options=options,
+                transform=head_transform,
+                dimension_x=20.0,
+                dimension_y=40.0,
+                dimension_z=100.0,
+                steps_x=1,
+                steps_y=1,
+                steps_z=1,
+                origin=unreal.GeometryScriptPrimitiveOriginMode.CENTER
+            )
+        else:
+            unreal.GeometryScript_MeshPrimitiveFunctions.append_cylinder(
+                target_mesh=dyn_mesh,
+                primitive_options=options,
+                transform=post_transform,
+                radius=10.0,
+                height=300.0,
+                radial_steps=8,
+                height_steps=1,
+                capped=True,
+                origin=unreal.GeometryScriptPrimitiveOriginMode.CENTER
+            )
+            # Box head
+            head_transform = unreal.Transform()
+            head_transform.translation = [15.0, 0.0, 260.0]
+            unreal.GeometryScript_MeshPrimitiveFunctions.append_box(
+                target_mesh=dyn_mesh,
+                primitive_options=options,
+                transform=head_transform,
+                dimension_x=20.0,
+                dimension_y=40.0,
+                dimension_z=100.0,
+                steps_x=1,
+                steps_y=1,
+                steps_z=1,
+                origin=unreal.GeometryScriptPrimitiveOriginMode.CENTER
+            )
+    except Exception as e:
+        print(f"GeometryScript generation failed: {e}")
+        return
+
+    create_options = unreal.GeometryScriptCreateNewStaticMeshAssetOptions()
+    try:
+        if hasattr(unreal, "GeometryScriptLibrary_CreateNewStaticMeshAssetFromDynamicMesh"):
+            static_mesh = unreal.GeometryScriptLibrary_CreateNewStaticMeshAssetFromDynamicMesh.create_new_static_mesh_asset_from_dynamic_mesh(
+                dynamic_mesh=dyn_mesh,
+                asset_path_and_name=mesh_path,
+                options=create_options
+            )
+        else:
+            static_mesh = unreal.GeometryScript_AssetUtils.create_new_static_mesh_asset_from_dynamic_mesh(
+                dynamic_mesh=dyn_mesh,
+                asset_path_and_name=mesh_path,
+                options=create_options
+            )
+
+        # Apply material
+        assign_material_to_mesh(static_mesh, mat_inst)
+    except Exception as e:
+        print(f"GeometryScript bake failed: {e}")
+
 def main():
     base_dir = '/Game/Art/Models/Urban'
     mat_dir = '/Game/Art/Materials'
@@ -365,12 +462,18 @@ def main():
     bench_mat_path = f"{mat_dir}/MI_UrbanBench"
     bench_mat = create_material_instance(bench_mat_path, master_mat, [0.4, 0.25, 0.1, 1.0], 0.6)
 
+    traffic_light_mat_path = f"{mat_dir}/MI_UrbanTrafficLight"
+    traffic_light_mat = create_material_instance(traffic_light_mat_path, master_mat, [0.1, 0.1, 0.1, 1.0], 0.3)
+
     # Programmatic 3D Modeling
     building_mesh_path = f"{base_dir}/SM_UrbanBuilding"
     generate_urban_building(building_mesh_path, building_mat)
 
     bench_mesh_path = f"{base_dir}/SM_UrbanBench"
     generate_urban_bench(bench_mesh_path, bench_mat)
+
+    traffic_light_mesh_path = f"{base_dir}/SM_UrbanTrafficLight"
+    generate_urban_traffic_light(traffic_light_mesh_path, traffic_light_mat)
 
     print("Asset generation for Urban biome complete.")
 


### PR DESCRIPTION
This PR adds a procedural asset generation script to build a `SM_UrbanTrafficLight` mesh and material instance using UE5's Geometry Scripting. It integrates the generated asset into the Urban Biome's PCG generation settings within `AdvancedBiomePCGSettings.cpp`.

This is part of the ongoing effort to populate the "BikeAdventure" project with 3D models.

---
*PR created automatically by Jules for task [13732900367077679884](https://jules.google.com/task/13732900367077679884) started by @zvirb*