### PR TITLE
🔒 Fix non-deterministic procedural generation seeds

### DIFF
--- a/Source/BikeAdventure/Systems/AdvancedBiomePCGSettings.cpp
+++ b/Source/BikeAdventure/Systems/AdvancedBiomePCGSettings.cpp
@@ -188,7 +188,8 @@ bool FAdvancedBiomeGenerationElement::ExecuteInternal(FPCGContext* Context) cons
             // Fall back to base implementation for other biomes
             {
                 const FBiomeGenerationParams& Params = Settings->GenerationParams;
-                FRandomStream LocalRandom(FMath::Rand());
+                int32 Seed = Context->SourceComponent.IsValid() ? Context->SourceComponent->Seed : 12345;
+                FRandomStream LocalRandom(Seed);
                 int32 NumPoints = FMath::RoundToInt(800.0f * Params.VegetationDensity);
                 
                 for (int32 i = 0; i < NumPoints; i++)
@@ -217,7 +218,8 @@ bool FAdvancedBiomeGenerationElement::ExecuteInternal(FPCGContext* Context) cons
 
 void FAdvancedBiomeGenerationElement::GenerateBeachLayout(FPCGContext* Context, const UBeachPCGSettings* Settings, TArray<FPCGPoint>& OutPoints) const
 {
-    FRandomStream Random(FMath::Rand());
+    int32 Seed = Context->SourceComponent.IsValid() ? Context->SourceComponent->Seed : 12345;
+    FRandomStream Random(Seed);
 
     // Generate palm trees
     int32 NumTrees = FMath::RoundToInt(400.0f * Settings->PalmTreeDensity);
@@ -274,7 +276,8 @@ void FAdvancedBiomeGenerationElement::GenerateBeachLayout(FPCGContext* Context, 
 
 void FAdvancedBiomeGenerationElement::GenerateForestLayout(FPCGContext* Context, const UForestPCGSettings* Settings, TArray<FPCGPoint>& OutPoints) const
 {
-    FRandomStream Random(FMath::Rand());
+    int32 Seed = Context->SourceComponent.IsValid() ? Context->SourceComponent->Seed : 12345;
+    FRandomStream Random(Seed);
 
     // Generate trees
     int32 NumTrees = FMath::RoundToInt(800.0f * Settings->TreeDensity);
@@ -329,7 +332,8 @@ void FAdvancedBiomeGenerationElement::GenerateForestLayout(FPCGContext* Context,
 
 void FAdvancedBiomeGenerationElement::GenerateUrbanLayout(FPCGContext* Context, const UUrbanPCGSettings* Settings, TArray<FPCGPoint>& OutPoints) const
 {
-    FRandomStream Random(FMath::Rand());
+    int32 Seed = Context->SourceComponent.IsValid() ? Context->SourceComponent->Seed : 12345;
+    FRandomStream Random(Seed);
     const FBiomeGenerationParams& Params = Settings->GenerationParams;
     
     // Generate buildings
@@ -431,7 +435,8 @@ void FAdvancedBiomeGenerationElement::GenerateUrbanLayout(FPCGContext* Context, 
 
 void FAdvancedBiomeGenerationElement::GenerateCountrysideLayout(FPCGContext* Context, const UCountrysidePCGSettings* Settings, TArray<FPCGPoint>& OutPoints) const
 {
-    FRandomStream Random(FMath::Rand());
+    int32 Seed = Context->SourceComponent.IsValid() ? Context->SourceComponent->Seed : 12345;
+    FRandomStream Random(Seed);
     
     // Generate farms
     int32 NumFarms = FMath::RoundToInt(10.0f * Settings->FarmDensity);
@@ -549,7 +554,8 @@ void FAdvancedBiomeGenerationElement::GenerateCountrysideLayout(FPCGContext* Con
 
 void FAdvancedBiomeGenerationElement::GenerateMountainTerrain(FPCGContext* Context, const UMountainPCGSettings* Settings, TArray<FPCGPoint>& OutPoints) const
 {
-    FRandomStream Random(FMath::Rand());
+    int32 Seed = Context->SourceComponent.IsValid() ? Context->SourceComponent->Seed : 12345;
+    FRandomStream Random(Seed);
     
     // Generate rock formations
     int32 NumRockFormations = FMath::RoundToInt(400.0f * Settings->RockFormationDensity);
@@ -639,7 +645,8 @@ void FAdvancedBiomeGenerationElement::GenerateMountainTerrain(FPCGContext* Conte
 
 void FAdvancedBiomeGenerationElement::GenerateWetlandsEcosystem(FPCGContext* Context, const UWetlandsPCGSettings* Settings, TArray<FPCGPoint>& OutPoints) const
 {
-    FRandomStream Random(FMath::Rand());
+    int32 Seed = Context->SourceComponent.IsValid() ? Context->SourceComponent->Seed : 12345;
+    FRandomStream Random(Seed);
     
     // Generate water bodies
     int32 NumWaterBodies = FMath::RoundToInt(20.0f * Settings->WaterBodyDensity);
@@ -726,7 +733,8 @@ void FAdvancedBiomeGenerationElement::GenerateWetlandsEcosystem(FPCGContext* Con
 
 void FAdvancedBiomeGenerationElement::GenerateDesertLayout(FPCGContext* Context, const UDesertPCGSettings* Settings, TArray<FPCGPoint>& OutPoints) const
 {
-    FRandomStream Random(FMath::Rand());
+    int32 Seed = Context->SourceComponent.IsValid() ? Context->SourceComponent->Seed : 12345;
+    FRandomStream Random(Seed);
 
     // Generate cacti
     int32 NumCacti = FMath::RoundToInt(200.0f * Settings->CactusDensity);

--- a/Source/BikeAdventure/Systems/BiomeGenerator.cpp
+++ b/Source/BikeAdventure/Systems/BiomeGenerator.cpp
@@ -239,7 +239,7 @@ AIntersection* UBiomeGenerator::GenerateIntersection(const FVector& Location, EB
         EIntersectionType Type = EIntersectionType::YFork;
         if (Rules.PreferredIntersectionTypes.Num() > 0)
         {
-                int32 Index = FMath::RandRange(0, Rules.PreferredIntersectionTypes.Num() - 1);
+                int32 Index = RandomStream.RandRange(0, Rules.PreferredIntersectionTypes.Num() - 1);
                 Type = Rules.PreferredIntersectionTypes[Index];
         }
 

--- a/Source/BikeAdventure/Systems/DiscoverySystem.cpp
+++ b/Source/BikeAdventure/Systems/DiscoverySystem.cpp
@@ -70,7 +70,8 @@ void UDiscoverySystem::LoadDefaultDiscoveries()
 void UDiscoverySystem::HandleBiomeEntered(EBiomeType BiomeType)
 {
 	// Randomly trigger a discovery for the entered biome
-	FRandomStream Random(FMath::Rand());
+	int32 BiomeSeed = SystemSeed + static_cast<int32>(BiomeType);
+	FRandomStream Random(BiomeSeed);
 	if (Random.FRand() < 0.3f) // 30% chance to find something
 	{
 		for (FDiscoveryData& Data : AvailableDiscoveries)

--- a/Source/BikeAdventure/Systems/DiscoverySystem.h
+++ b/Source/BikeAdventure/Systems/DiscoverySystem.h
@@ -31,6 +31,9 @@ class BIKEADVENTURE_API UDiscoverySystem : public UActorComponent
 public:	
 	UDiscoverySystem();
 
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Discovery")
+	int32 SystemSeed = 12345;
+
 	virtual void BeginPlay() override;
 
 	UFUNCTION(BlueprintCallable, Category = "Discovery System")

--- a/Source/BikeAdventure/Systems/PathPersonalitySystem.cpp
+++ b/Source/BikeAdventure/Systems/PathPersonalitySystem.cpp
@@ -3,7 +3,7 @@
 
 UPathPersonalitySystem::UPathPersonalitySystem()
 {
-    RandomStream.Initialize(FMath::Rand());
+    RandomStream.Initialize(12345);
 }
 
 void UPathPersonalitySystem::Initialize()


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is the use of non-deterministic random functions (`FMath::Rand()`, `FMath::RandRange()`) in procedural generation systems.

⚠️ **Risk:** Non-deterministic generation prevents route sharing and causes inconsistent world state across sessions for the same seed, which can lead to desynchronization in multiplayer or broken gameplay mechanics that rely on reproducibility.

🛡️ **Solution:** Replaced global random functions with deterministic `FRandomStream` logic.
- In `AdvancedBiomePCGSettings.cpp`, the seed is now derived from the `UPCGComponent` via the `FPCGContext`.
- In `PathPersonalitySystem.cpp`, a fixed deterministic seed is used in the constructor.
- In `DiscoverySystem.cpp`, a new `SystemSeed` property was added and combined with BiomeType to ensure discoveries are deterministic.
- In `BiomeGenerator.cpp`, `FMath::RandRange` was replaced with the existing `RandomStream.RandRange`.

---
*PR created automatically by Jules for task [18007565871571824190](https://jules.google.com/task/18007565871571824190) started by @zvirb*