### PR TITLE
Add Forest Log asset generation and integrate with PCG

### DIFF
--- a/Source/BikeAdventure/Systems/AdvancedBiomePCGSettings.cpp
+++ b/Source/BikeAdventure/Systems/AdvancedBiomePCGSettings.cpp
@@ -23,10 +23,12 @@ UForestPCGSettings::UForestPCGSettings()
     BiomeType = EBiomeType::Forest;
     TreeDensity = 0.4f; // Lowered to meet 60 FPS constraint
     RockDensity = 0.3f;
+    LogDensity = 0.2f;
 
     // Add programmatic assets to arrays
     TreeMeshes.Add(TSoftObjectPtr<UStaticMesh>(FSoftObjectPath(TEXT("/Game/Art/Models/Forest/SM_PineTree.SM_PineTree"))));
     RockMeshes.Add(TSoftObjectPtr<UStaticMesh>(FSoftObjectPath(TEXT("/Game/Art/Models/Forest/SM_ForestRock.SM_ForestRock"))));
+    LogMeshes.Add(TSoftObjectPtr<UStaticMesh>(FSoftObjectPath(TEXT("/Game/Art/Models/Forest/SM_ForestLog.SM_ForestLog"))));
 }
 
 // Urban PCG Settings

--- a/Source/BikeAdventure/Systems/AdvancedBiomePCGSettings.h
+++ b/Source/BikeAdventure/Systems/AdvancedBiomePCGSettings.h
@@ -53,6 +53,10 @@ public:
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "Forest Generation", meta = (ClampMin = "0.0", ClampMax = "1.0"))
     float RockDensity;
 
+    // Log density
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "Forest Generation", meta = (ClampMin = "0.0", ClampMax = "1.0"))
+    float LogDensity;
+
     // Tree meshes
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "Forest Assets")
     TArray<TSoftObjectPtr<UStaticMesh>> TreeMeshes;
@@ -60,6 +64,10 @@ public:
     // Rock meshes
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "Forest Assets")
     TArray<TSoftObjectPtr<UStaticMesh>> RockMeshes;
+
+    // Log meshes
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "Forest Assets")
+    TArray<TSoftObjectPtr<UStaticMesh>> LogMeshes;
 };
 
 /**

--- a/docs/ART_PIPELINE.md
+++ b/docs/ART_PIPELINE.md
@@ -37,8 +37,8 @@ As part of the goal to dynamically generate content, there are Python scripts in
 
 The scripts will:
 - Create `/Game/Art/Models/Forest/`, `/Game/Art/Models/Mountains/`, `/Game/Art/Models/Urban/`, `/Game/Art/Models/Countryside/`, `/Game/Art/Models/Desert/`, `/Game/Art/Models/Beach/`, `/Game/Art/Models/Wetlands/`, `/Game/Art/Models/Character/`, and `/Game/Art/Materials/`.
-- Procedurally generate `SM_PineTree` and `SM_ForestRock` for Forest, `SM_MountainRock`, `SM_MountainCliff`, and `SM_AlpinePlant` for Mountains, `SM_UrbanBuilding`, `SM_UrbanBench`, and `SM_UrbanTrafficLight` for Urban, `SM_PalmTree` and `SM_Sandcastle` for Beach, `SM_FarmHouse`, `SM_CountrysideFence`, `SM_Crop`, and `SM_Animal` for Countryside, `SM_WaterBody`, `SM_MarshPlant`, and `SM_WetlandsBridge` for Wetlands, and `SM_Bike` for the Main Bike Character using simple primitive and geometry boolean/noise functions.
-- Procedurally construct master materials like `M_StylizedMaster` and `M_StylizedUrban`, and derived material instances (e.g., `MI_MountainRock`, `MI_UrbanBuilding`).
+- Procedurally generate `SM_PineTree`, `SM_ForestRock`, and `SM_ForestLog` for Forest, `SM_MountainRock`, `SM_MountainCliff`, and `SM_AlpinePlant` for Mountains, `SM_UrbanBuilding`, `SM_UrbanBench`, and `SM_UrbanTrafficLight` for Urban, `SM_PalmTree` and `SM_Sandcastle` for Beach, `SM_FarmHouse`, `SM_CountrysideFence`, `SM_Crop`, and `SM_Animal` for Countryside, `SM_WaterBody`, `SM_MarshPlant`, and `SM_WetlandsBridge` for Wetlands, and `SM_Bike` for the Main Bike Character using simple primitive and geometry boolean/noise functions.
+- Procedurally construct master materials like `M_StylizedMaster` and `M_StylizedUrban`, and derived material instances (e.g., `MI_MountainRock`, `MI_UrbanBuilding`, `MI_ForestLog`).
 - Assign these material instances to the corresponding static meshes.
 
 These meshes are then automatically linked into the PCG spawning logic for their respective biomes via C++ (e.g., `UMountainPCGSettings` and `UUrbanPCGSettings`).

--- a/scripts/asset_generation/generate_forest_assets.py
+++ b/scripts/asset_generation/generate_forest_assets.py
@@ -111,6 +111,42 @@ def generate_forest_rock(mesh_path, mat_inst):
         print(f"GeometryScript bake failed: {e}")
 
 
+def generate_forest_log(mesh_path, mat_inst):
+    if unreal.EditorAssetLibrary.does_asset_exist(mesh_path):
+        print(f"Asset already exists: {mesh_path}")
+        return
+
+    dyn_mesh = asset_utils.create_dynamic_mesh()
+    options = unreal.GeometryScriptPrimitiveOptions()
+    primitive_functions = asset_utils.get_geometry_script_primitive_functions()
+
+    transform = unreal.Transform()
+    # Rotate cylinder to lie horizontally
+    transform.rotation = unreal.Rotator(0, 0, 90).quaternion()
+
+    try:
+        primitive_functions.append_cylinder(
+            target_mesh=dyn_mesh,
+            primitive_options=options,
+            transform=transform,
+            radius=20.0,
+            height=150.0,
+            radial_steps=8,
+            height_steps=1,
+            capped=True,
+            origin=unreal.GeometryScriptPrimitiveOriginMode.CENTER
+        )
+    except Exception as e:
+        print(f"GeometryScript generation failed: {e}")
+        return
+
+    try:
+        static_mesh = asset_utils.create_static_mesh_from_dynamic_mesh(dyn_mesh, mesh_path)
+        asset_utils.assign_material_to_mesh(static_mesh, mat_inst)
+    except Exception as e:
+        print(f"GeometryScript bake failed: {e}")
+
+
 def main():
     base_dir = '/Game/Art/Models/Forest'
     mat_dir = '/Game/Art/Materials'
@@ -122,16 +158,22 @@ def main():
     master_mat = asset_utils.create_master_material(master_mat_path)
 
     pine_mat_path = f"{mat_dir}/MI_PineTree"
-    pine_mat = create_material_instance(pine_mat_path, master_mat, [0.05, 0.25, 0.05, 1.0], 0.8)
+    pine_mat = asset_utils.create_material_instance(pine_mat_path, master_mat, [0.05, 0.25, 0.05, 1.0], 0.8)
 
     rock_mat_path = f"{mat_dir}/MI_ForestRock"
-    rock_mat = create_material_instance(rock_mat_path, master_mat, [0.35, 0.35, 0.32, 1.0], 0.9)
+    rock_mat = asset_utils.create_material_instance(rock_mat_path, master_mat, [0.35, 0.35, 0.32, 1.0], 0.9)
+
+    log_mat_path = f"{mat_dir}/MI_ForestLog"
+    log_mat = asset_utils.create_material_instance(log_mat_path, master_mat, [0.25, 0.15, 0.05, 1.0], 0.8)
 
     pine_mesh_path = f"{base_dir}/SM_PineTree"
     generate_pine_tree(pine_mesh_path, pine_mat)
 
     rock_mesh_path = f"{base_dir}/SM_ForestRock"
     generate_forest_rock(rock_mesh_path, rock_mat)
+
+    log_mesh_path = f"{base_dir}/SM_ForestLog"
+    generate_forest_log(log_mesh_path, log_mat)
 
     print("Asset generation for Forest biome complete.")
 


### PR DESCRIPTION
Add Forest Log asset generation and integrate with PCG

- Added `generate_forest_log` function to `generate_forest_assets.py` using Unreal Geometry Scripting to create a procedural cylinder mesh.
- Fixed a bug in `generate_forest_assets.py` where `create_material_instance` lacked the `asset_utils.` prefix causing `NameError` execution failures.
- Updated `UForestPCGSettings` in C++ (`AdvancedBiomePCGSettings.h` and `.cpp`) to declare and initialize `LogDensity` and `LogMeshes` with a SoftObjectPtr to the new `/Game/Art/Models/Forest/SM_ForestLog` path.
- Created `MI_ForestLog` material instance with a brown hue for realistic stylized appearance.
- Updated `docs/ART_PIPELINE.md` to reflect the generation of the new Forest log asset and material.
- Ensured testing suites pass (Gauntlet, Unit, Integration, Performance) and ephemeral test artifacts are clean.

---
*PR created automatically by Jules for task [639790869722002235](https://jules.google.com/task/639790869722002235) started by @zvirb*