### PR TITLE
Add Cave meshes generation for Mountain PCG Settings

### DIFF
--- a/Source/BikeAdventure/Systems/AdvancedBiomePCGSettings.cpp
+++ b/Source/BikeAdventure/Systems/AdvancedBiomePCGSettings.cpp
@@ -78,6 +78,7 @@ UMountainPCGSettings::UMountainPCGSettings()
     RockMeshes.Add(TSoftObjectPtr<UStaticMesh>(FSoftObjectPath(TEXT("/Game/Art/Models/Mountains/SM_MountainRock.SM_MountainRock"))));
     AlpinePlantMeshes.Add(TSoftObjectPtr<UStaticMesh>(FSoftObjectPath(TEXT("/Game/Art/Models/Mountains/SM_AlpinePlant.SM_AlpinePlant"))));
     CliffMeshes.Add(TSoftObjectPtr<UStaticMesh>(FSoftObjectPath(TEXT("/Game/Art/Models/Mountains/SM_MountainCliff.SM_MountainCliff"))));
+    CaveMeshes.Add(TSoftObjectPtr<UStaticMesh>(FSoftObjectPath(TEXT("/Game/Art/Models/Mountains/SM_MountainCave.SM_MountainCave"))));
 }
 
 // Desert PCG Settings

--- a/Source/BikeAdventure/Systems/AdvancedBiomePCGSettings.h
+++ b/Source/BikeAdventure/Systems/AdvancedBiomePCGSettings.h
@@ -209,6 +209,10 @@ public:
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "Mountain Assets")
     TArray<TSoftObjectPtr<UStaticMesh>> AlpinePlantMeshes;
 
+    // Cave entrance meshes
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "Mountain Assets")
+    TArray<TSoftObjectPtr<UStaticMesh>> CaveMeshes;
+
     // Snow and ice effects
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "Mountain Effects")
     TArray<TSoftObjectPtr<UNiagaraSystem>> SnowEffects;

--- a/scripts/asset_generation/generate_mountain_assets.py
+++ b/scripts/asset_generation/generate_mountain_assets.py
@@ -167,6 +167,124 @@ def generate_mountain_rock(mesh_path, mat_inst):
     except Exception as e:
         print(f"GeometryScript bake failed: {e}")
 
+def generate_mountain_cave(mesh_path, mat_inst):
+    if unreal.EditorAssetLibrary.does_asset_exist(mesh_path):
+        print(f"Asset already exists: {mesh_path}")
+        return
+
+    try:
+        dyn_mesh = unreal.GeometryScriptLibrary_CreateNewDynamicMesh.create_new_dynamic_mesh()
+        dyn_mesh_subtract = unreal.GeometryScriptLibrary_CreateNewDynamicMesh.create_new_dynamic_mesh()
+    except AttributeError:
+        try:
+            dyn_mesh = unreal.GeometryScript_AssetUtils.create_new_dynamic_mesh()
+            dyn_mesh_subtract = unreal.GeometryScript_AssetUtils.create_new_dynamic_mesh()
+        except AttributeError:
+            dyn_mesh = unreal.DynamicMesh()
+            dyn_mesh_subtract = unreal.DynamicMesh()
+
+    options = unreal.GeometryScriptPrimitiveOptions()
+
+    try:
+        if hasattr(unreal, "GeometryScriptLibrary_MeshPrimitiveFunctions"):
+            # Outer Cave Rock Structure
+            base_transform = unreal.Transform()
+            unreal.GeometryScriptLibrary_MeshPrimitiveFunctions.append_box(
+                target_mesh=dyn_mesh,
+                primitive_options=options,
+                transform=base_transform,
+                dimension_x=300.0,
+                dimension_y=350.0,
+                dimension_z=200.0,
+                steps_x=3,
+                steps_y=3,
+                steps_z=3,
+                origin=unreal.GeometryScriptPrimitiveOriginMode.BASE
+            )
+
+            # Inner empty space to subtract
+            subtract_transform = unreal.Transform()
+            subtract_transform.translation = [50.0, 0.0, 0.0]
+            unreal.GeometryScriptLibrary_MeshPrimitiveFunctions.append_box(
+                target_mesh=dyn_mesh_subtract,
+                primitive_options=options,
+                transform=subtract_transform,
+                dimension_x=220.0,
+                dimension_y=150.0,
+                dimension_z=120.0,
+                steps_x=3,
+                steps_y=3,
+                steps_z=3,
+                origin=unreal.GeometryScriptPrimitiveOriginMode.BASE
+            )
+
+            if hasattr(unreal, "GeometryScriptLibrary_MeshBooleanFunctions"):
+                unreal.GeometryScriptLibrary_MeshBooleanFunctions.apply_mesh_boolean(
+                    target_mesh=dyn_mesh,
+                    tool_mesh=dyn_mesh_subtract,
+                    operation=unreal.GeometryScriptBooleanOperation.SUBTRACT
+                )
+        else:
+            # Outer Cave Rock Structure
+            base_transform = unreal.Transform()
+            unreal.GeometryScript_MeshPrimitiveFunctions.append_box(
+                target_mesh=dyn_mesh,
+                primitive_options=options,
+                transform=base_transform,
+                dimension_x=300.0,
+                dimension_y=350.0,
+                dimension_z=200.0,
+                steps_x=3,
+                steps_y=3,
+                steps_z=3,
+                origin=unreal.GeometryScriptPrimitiveOriginMode.BASE
+            )
+
+            # Inner empty space to subtract
+            subtract_transform = unreal.Transform()
+            subtract_transform.translation = [50.0, 0.0, 0.0]
+            unreal.GeometryScript_MeshPrimitiveFunctions.append_box(
+                target_mesh=dyn_mesh_subtract,
+                primitive_options=options,
+                transform=subtract_transform,
+                dimension_x=220.0,
+                dimension_y=150.0,
+                dimension_z=120.0,
+                steps_x=3,
+                steps_y=3,
+                steps_z=3,
+                origin=unreal.GeometryScriptPrimitiveOriginMode.BASE
+            )
+
+            if hasattr(unreal, "GeometryScript_MeshBooleanFunctions"):
+                unreal.GeometryScript_MeshBooleanFunctions.apply_mesh_boolean(
+                    target_mesh=dyn_mesh,
+                    tool_mesh=dyn_mesh_subtract,
+                    operation=unreal.GeometryScriptBooleanOperation.SUBTRACT
+                )
+    except Exception as e:
+        print(f"GeometryScript generation failed: {e}")
+        return
+
+    create_options = unreal.GeometryScriptCreateNewStaticMeshAssetOptions()
+    try:
+        if hasattr(unreal, "GeometryScriptLibrary_CreateNewStaticMeshAssetFromDynamicMesh"):
+            static_mesh = unreal.GeometryScriptLibrary_CreateNewStaticMeshAssetFromDynamicMesh.create_new_static_mesh_asset_from_dynamic_mesh(
+                dynamic_mesh=dyn_mesh,
+                asset_path_and_name=mesh_path,
+                options=create_options
+            )
+        else:
+            static_mesh = unreal.GeometryScript_AssetUtils.create_new_static_mesh_asset_from_dynamic_mesh(
+                dynamic_mesh=dyn_mesh,
+                asset_path_and_name=mesh_path,
+                options=create_options
+            )
+
+        # Apply material
+        assign_material_to_mesh(static_mesh, mat_inst)
+    except Exception as e:
+        print(f"GeometryScript bake failed: {e}")
 
 def main():
     base_dir = '/Game/Art/Models/Mountains'
@@ -189,6 +307,9 @@ def main():
     cliff_mat_path = f"{mat_dir}/MI_MountainCliff"
     cliff_mat = asset_utils.create_material_instance(cliff_mat_path, master_mat, [0.4, 0.35, 0.35, 1.0], 0.9)
 
+    cave_mat_path = f"{mat_dir}/MI_MountainCave"
+    cave_mat = asset_utils.create_material_instance(cave_mat_path, master_mat, [0.15, 0.15, 0.15, 1.0], 0.95)
+
     # Programmatic 3D Modeling
     plant_mesh_path = f"{base_dir}/SM_AlpinePlant"
     generate_alpine_plant(plant_mesh_path, plant_mat)
@@ -198,6 +319,9 @@ def main():
 
     cliff_mesh_path = f"{base_dir}/SM_MountainCliff"
     generate_mountain_cliff(cliff_mesh_path, cliff_mat)
+
+    cave_mesh_path = f"{base_dir}/SM_MountainCave"
+    generate_mountain_cave(cave_mesh_path, cave_mat)
 
     print("Asset generation for Mountains biome complete.")
 


### PR DESCRIPTION
Add Cave meshes generation for Mountain PCG Settings

- Added `CaveMeshes` property to `UMountainPCGSettings` array in `AdvancedBiomePCGSettings.h`.
- Initialized `CaveMeshes` mapping in `AdvancedBiomePCGSettings.cpp` to properly link `/Game/Art/Models/Mountains/SM_MountainCave.SM_MountainCave`.
- Updated Python Geometry Script `generate_mountain_assets.py` to procedurally carve and generate `SM_MountainCave` and construct its master material `MI_MountainCave`.

---
*PR created automatically by Jules for task [10391976586242354560](https://jules.google.com/task/10391976586242354560) started by @zvirb*