### PR TITLE
feat: Procedural Urban Park Tree Asset Generation

### DIFF
--- a/Source/BikeAdventure/Systems/AdvancedBiomePCGSettings.cpp
+++ b/Source/BikeAdventure/Systems/AdvancedBiomePCGSettings.cpp
@@ -44,6 +44,7 @@ UUrbanPCGSettings::UUrbanPCGSettings()
     BuildingMeshes.Add(TSoftObjectPtr<UStaticMesh>(FSoftObjectPath(TEXT("/Game/Art/Models/Urban/SM_UrbanBuilding.SM_UrbanBuilding"))));
     StreetFurnitureMeshes.Add(TSoftObjectPtr<UStaticMesh>(FSoftObjectPath(TEXT("/Game/Art/Models/Urban/SM_UrbanBench.SM_UrbanBench"))));
     TrafficElementMeshes.Add(TSoftObjectPtr<UStaticMesh>(FSoftObjectPath(TEXT("/Game/Art/Models/Urban/SM_UrbanTrafficLight.SM_UrbanTrafficLight"))));
+    ParkTreeMeshes.Add(TSoftObjectPtr<UStaticMesh>(FSoftObjectPath(TEXT("/Game/Art/Models/Urban/SM_UrbanParkTree.SM_UrbanParkTree"))));
 }
 
 // Countryside PCG Settings

--- a/Source/BikeAdventure/Systems/AdvancedBiomePCGSettings.h
+++ b/Source/BikeAdventure/Systems/AdvancedBiomePCGSettings.h
@@ -109,6 +109,10 @@ public:
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "Urban Assets")
     TArray<TSoftObjectPtr<UStaticMesh>> TrafficElementMeshes;
 
+    // Park tree meshes
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "Urban Assets")
+    TArray<TSoftObjectPtr<UStaticMesh>> ParkTreeMeshes;
+
     // Urban lighting setups
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "Urban Lighting")
     TArray<TSoftObjectPtr<class UPointLightComponent>> LightingPresets;

--- a/docs/ART_PIPELINE.md
+++ b/docs/ART_PIPELINE.md
@@ -31,13 +31,13 @@ As part of the goal to dynamically generate content, there are Python scripts in
    exec(open("C:/Path/To/Your/Repo/scripts/asset_generation/generate_beach_assets.py").read())
    exec(open("C:/Path/To/Your/Repo/scripts/asset_generation/generate_bike_assets.py").read())
    ```
-   Or if you prefer right-clicking, you can drag and drop `generate_forest_assets.py`, `generate_mountain_assets.py`, `generate_urban_assets.py`, `generate_countryside_assets.py`, `generate_wetlands_assets.py`, `generate_desert_assets.py`, `generate_beach_assets.py`, or `generate_bike_assets.py` into the Content Browser, right click the asset, and select **Run Editor Utility Python Script**.
+   Or if you prefer right-clicking, you can drag and drop any of the above python scripts (e.g., `generate_urban_assets.py`) into the Content Browser, right click the asset, and select **Run Editor Utility Python Script**.
 
 ### Asset Outputs
 
 The scripts will:
 - Create `/Game/Art/Models/Forest/`, `/Game/Art/Models/Mountains/`, `/Game/Art/Models/Urban/`, `/Game/Art/Models/Countryside/`, `/Game/Art/Models/Desert/`, `/Game/Art/Models/Beach/`, `/Game/Art/Models/Wetlands/`, `/Game/Art/Models/Character/`, and `/Game/Art/Materials/`.
-- Procedurally generate `SM_PineTree`, `SM_ForestRock`, and `SM_ForestLog` for Forest, `SM_MountainRock`, `SM_MountainCliff`, and `SM_AlpinePlant` for Mountains, `SM_UrbanBuilding`, `SM_UrbanBench`, and `SM_UrbanTrafficLight` for Urban, `SM_PalmTree` and `SM_Sandcastle` for Beach, `SM_FarmHouse`, `SM_CountrysideFence`, `SM_Crop`, and `SM_Animal` for Countryside, `SM_WaterBody`, `SM_MarshPlant`, and `SM_WetlandsBridge` for Wetlands, `SM_DesertCactus`, `SM_DesertRock`, and `SM_DesertDune` for Desert, and `SM_Bike` for the Main Bike Character using simple primitive and geometry boolean/noise functions.
+- Procedurally generate `SM_PineTree`, `SM_ForestRock`, and `SM_ForestLog` for Forest, `SM_MountainRock`, `SM_MountainCliff`, and `SM_AlpinePlant` for Mountains, `SM_UrbanBuilding`, `SM_UrbanBench`, `SM_UrbanTrafficLight`, and `SM_UrbanParkTree` for Urban, `SM_PalmTree` and `SM_Sandcastle` for Beach, `SM_FarmHouse`, `SM_CountrysideFence`, `SM_Crop`, and `SM_Animal` for Countryside, `SM_WaterBody`, `SM_MarshPlant`, and `SM_WetlandsBridge` for Wetlands, `SM_DesertCactus`, `SM_DesertRock`, and `SM_DesertDune` for Desert, and `SM_Bike` for the Main Bike Character using simple primitive and geometry boolean/noise functions.
 - Procedurally construct master materials like `M_StylizedMaster` and `M_StylizedUrban`, and derived material instances (e.g., `MI_MountainRock`, `MI_UrbanBuilding`, `MI_ForestLog`).
 - Assign these material instances to the corresponding static meshes.
 

--- a/scripts/asset_generation/generate_urban_assets.py
+++ b/scripts/asset_generation/generate_urban_assets.py
@@ -213,6 +213,99 @@ def generate_urban_traffic_light(mesh_path, mat_inst):
     except Exception as e:
         print(f"GeometryScript bake failed: {e}")
 
+
+def generate_urban_park_tree(mesh_path, mat_inst):
+    if unreal.EditorAssetLibrary.does_asset_exist(mesh_path):
+        print(f"Asset already exists: {mesh_path}")
+        return
+
+    try:
+        dyn_mesh = unreal.GeometryScriptLibrary_CreateNewDynamicMesh.create_new_dynamic_mesh()
+    except AttributeError:
+        try:
+            dyn_mesh = unreal.GeometryScript_AssetUtils.create_new_dynamic_mesh()
+        except AttributeError:
+            dyn_mesh = unreal.DynamicMesh()
+
+    options = unreal.GeometryScriptPrimitiveOptions()
+
+    try:
+        if hasattr(unreal, "GeometryScriptLibrary_MeshPrimitiveFunctions"):
+            # Trunk
+            trunk_transform = unreal.Transform()
+            unreal.GeometryScriptLibrary_MeshPrimitiveFunctions.append_cylinder(
+                target_mesh=dyn_mesh,
+                primitive_options=options,
+                transform=trunk_transform,
+                radius=15.0,
+                height=150.0,
+                radial_steps=8,
+                height_steps=1,
+                capped=True,
+                origin=unreal.GeometryScriptPrimitiveOriginMode.BASE
+            )
+            # Leaves
+            leaves_transform = unreal.Transform()
+            leaves_transform.translation = [0.0, 0.0, 120.0]
+            unreal.GeometryScriptLibrary_MeshPrimitiveFunctions.append_sphere(
+                target_mesh=dyn_mesh,
+                primitive_options=options,
+                transform=leaves_transform,
+                radius=100.0,
+                steps_x=12,
+                steps_y=12,
+                origin=unreal.GeometryScriptPrimitiveOriginMode.BASE
+            )
+        else:
+            # Trunk
+            trunk_transform = unreal.Transform()
+            unreal.GeometryScript_MeshPrimitiveFunctions.append_cylinder(
+                target_mesh=dyn_mesh,
+                primitive_options=options,
+                transform=trunk_transform,
+                radius=15.0,
+                height=150.0,
+                radial_steps=8,
+                height_steps=1,
+                capped=True,
+                origin=unreal.GeometryScriptPrimitiveOriginMode.BASE
+            )
+            # Leaves
+            leaves_transform = unreal.Transform()
+            leaves_transform.translation = [0.0, 0.0, 120.0]
+            unreal.GeometryScript_MeshPrimitiveFunctions.append_sphere(
+                target_mesh=dyn_mesh,
+                primitive_options=options,
+                transform=leaves_transform,
+                radius=100.0,
+                steps_x=12,
+                steps_y=12,
+                origin=unreal.GeometryScriptPrimitiveOriginMode.BASE
+            )
+    except Exception as e:
+        print(f"GeometryScript generation failed: {e}")
+        return
+
+    create_options = unreal.GeometryScriptCreateNewStaticMeshAssetOptions()
+    try:
+        if hasattr(unreal, "GeometryScriptLibrary_CreateNewStaticMeshAssetFromDynamicMesh"):
+            static_mesh = unreal.GeometryScriptLibrary_CreateNewStaticMeshAssetFromDynamicMesh.create_new_static_mesh_asset_from_dynamic_mesh(
+                dynamic_mesh=dyn_mesh,
+                asset_path_and_name=mesh_path,
+                options=create_options
+            )
+        else:
+            static_mesh = unreal.GeometryScript_AssetUtils.create_new_static_mesh_asset_from_dynamic_mesh(
+                dynamic_mesh=dyn_mesh,
+                asset_path_and_name=mesh_path,
+                options=create_options
+            )
+
+        # Apply material
+        assign_material_to_mesh(static_mesh, mat_inst)
+    except Exception as e:
+        print(f"GeometryScript bake failed: {e}")
+
 def main():
     base_dir = '/Game/Art/Models/Urban'
     mat_dir = '/Game/Art/Materials'
@@ -234,6 +327,9 @@ def main():
     traffic_light_mat_path = f"{mat_dir}/MI_UrbanTrafficLight"
     traffic_light_mat = asset_utils.create_material_instance(traffic_light_mat_path, master_mat, [0.1, 0.1, 0.1, 1.0], 0.3)
 
+    park_tree_mat_path = f"{mat_dir}/MI_UrbanParkTree"
+    park_tree_mat = asset_utils.create_material_instance(park_tree_mat_path, master_mat, [0.1, 0.5, 0.1, 1.0], 0.8)
+
     # Programmatic 3D Modeling
     building_mesh_path = f"{base_dir}/SM_UrbanBuilding"
     generate_urban_building(building_mesh_path, building_mat)
@@ -243,6 +339,9 @@ def main():
 
     traffic_light_mesh_path = f"{base_dir}/SM_UrbanTrafficLight"
     generate_urban_traffic_light(traffic_light_mesh_path, traffic_light_mat)
+
+    park_tree_mesh_path = f"{base_dir}/SM_UrbanParkTree"
+    generate_urban_park_tree(park_tree_mesh_path, park_tree_mat)
 
     print("Asset generation for Urban biome complete.")
 


### PR DESCRIPTION
Implemented a procedural asset generator for the Urban biome to populate its `GreenSpaceChance`. Created an "Urban Park Tree" via UE5 Python Editor scripts with a cylindrical trunk and spherical leaves to fit the <4GB memory, 60+ FPS constraint. A matching stylized green material is generated automatically. 

The Python script is idempotent, checking if the asset exists before overwriting. I added the required `TArray<TSoftObjectPtr<UStaticMesh>> ParkTreeMeshes` into `UUrbanPCGSettings` and assigned the newly built `/Game/Art/Models/Urban/SM_UrbanParkTree.SM_UrbanParkTree` into its default constructor. Updated documentation accordingly.

---
*PR created automatically by Jules for task [17345634036931222336](https://jules.google.com/task/17345634036931222336) started by @zvirb*