### PR TITLE
feat(art): add procedural generation for beach rocks and chairs

### DIFF
--- a/Source/BikeAdventure/Systems/AdvancedBiomePCGSettings.cpp
+++ b/Source/BikeAdventure/Systems/AdvancedBiomePCGSettings.cpp
@@ -11,10 +11,14 @@ UBeachPCGSettings::UBeachPCGSettings()
     BiomeType = EBiomeType::Beach;
     PalmTreeDensity = 0.3f;
     SandcastleChance = 0.1f;
+    RockDensity = 0.2f;
+    ChairChance = 0.15f;
 
     // Add programmatic assets to arrays
     PalmTreeMeshes.Add(TSoftObjectPtr<UStaticMesh>(FSoftObjectPath(TEXT("/Game/Art/Models/Beach/SM_PalmTree.SM_PalmTree"))));
     SandcastleMeshes.Add(TSoftObjectPtr<UStaticMesh>(FSoftObjectPath(TEXT("/Game/Art/Models/Beach/SM_Sandcastle.SM_Sandcastle"))));
+    RockMeshes.Add(TSoftObjectPtr<UStaticMesh>(FSoftObjectPath(TEXT("/Game/Art/Models/Beach/SM_BeachRock.SM_BeachRock"))));
+    ChairMeshes.Add(TSoftObjectPtr<UStaticMesh>(FSoftObjectPath(TEXT("/Game/Art/Models/Beach/SM_BeachChair.SM_BeachChair"))));
 }
 
 // Forest PCG Settings
@@ -280,6 +284,58 @@ void FAdvancedBiomeGenerationElement::GenerateBeachLayout(FPCGContext* Context, 
             ApplyBiomeAttributes(SandcastlePoint, EBiomeType::Beach, TEXT("Sandcastle"));
 
             OutPoints.Add(SandcastlePoint);
+        }
+    }
+
+    // Generate rocks
+    int32 NumRocks = FMath::RoundToInt(150.0f * Settings->RockDensity);
+    for (int32 i = 0; i < NumRocks; i++)
+    {
+        FVector Location(
+            Random.FRandRange(-2000.0f, 2000.0f),
+            Random.FRandRange(-2000.0f, 2000.0f),
+            0.0f
+        );
+
+        FRotator Rotation(
+            Random.FRandRange(-20.0f, 20.0f),
+            Random.FRandRange(0.0f, 360.0f),
+            Random.FRandRange(-20.0f, 20.0f)
+        );
+
+        FVector Scale(Random.FRandRange(0.5f, 1.8f));
+
+        FPCGPoint RockPoint = CreateBiomePoint(Location, Rotation, Scale, EBiomeType::Beach, 2);
+        RockPoint.Density = Settings->RockDensity;
+        ApplyBiomeAttributes(RockPoint, EBiomeType::Beach, TEXT("BeachRock"));
+
+        OutPoints.Add(RockPoint);
+    }
+
+    // Generate beach chairs
+    if (Random.FRand() < Settings->ChairChance)
+    {
+        int32 NumChairs = Random.RandRange(1, 8);
+        for (int32 i = 0; i < NumChairs; i++)
+        {
+            FVector Location(
+                Random.FRandRange(-1500.0f, 1500.0f),
+                Random.FRandRange(-1500.0f, 1500.0f),
+                0.0f
+            );
+
+            FRotator Rotation(
+                0.0f,
+                Random.FRandRange(0.0f, 360.0f),
+                0.0f
+            );
+
+            FVector Scale(Random.FRandRange(0.8f, 1.2f));
+
+            FPCGPoint ChairPoint = CreateBiomePoint(Location, Rotation, Scale, EBiomeType::Beach, 3);
+            ApplyBiomeAttributes(ChairPoint, EBiomeType::Beach, TEXT("BeachChair"));
+
+            OutPoints.Add(ChairPoint);
         }
     }
 }

--- a/Source/BikeAdventure/Systems/AdvancedBiomePCGSettings.h
+++ b/Source/BikeAdventure/Systems/AdvancedBiomePCGSettings.h
@@ -25,6 +25,14 @@ public:
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "Beach Generation", meta = (ClampMin = "0.0", ClampMax = "1.0"))
     float SandcastleChance;
 
+    // Rock density
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "Beach Generation", meta = (ClampMin = "0.0", ClampMax = "1.0"))
+    float RockDensity;
+
+    // Chair probability
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "Beach Generation", meta = (ClampMin = "0.0", ClampMax = "1.0"))
+    float ChairChance;
+
     // Palm tree meshes
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "Beach Assets")
     TArray<TSoftObjectPtr<UStaticMesh>> PalmTreeMeshes;
@@ -32,6 +40,14 @@ public:
     // Sandcastle meshes
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "Beach Assets")
     TArray<TSoftObjectPtr<UStaticMesh>> SandcastleMeshes;
+
+    // Rock meshes
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "Beach Assets")
+    TArray<TSoftObjectPtr<UStaticMesh>> RockMeshes;
+
+    // Chair meshes
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "Beach Assets")
+    TArray<TSoftObjectPtr<UStaticMesh>> ChairMeshes;
 };
 
 /**

--- a/docs/ART_PIPELINE.md
+++ b/docs/ART_PIPELINE.md
@@ -29,6 +29,7 @@ As part of the goal to dynamically generate content, there are Python scripts in
    exec(open("C:/Path/To/Your/Repo/scripts/asset_generation/generate_wetlands_assets.py").read())
    exec(open("C:/Path/To/Your/Repo/scripts/asset_generation/generate_desert_assets.py").read())
    exec(open("C:/Path/To/Your/Repo/scripts/asset_generation/generate_beach_assets.py").read())
+   exec(open("C:/Path/To/Your/Repo/scripts/asset_generation/generate_beach_props.py").read())
    exec(open("C:/Path/To/Your/Repo/scripts/asset_generation/generate_bike_assets.py").read())
    ```
    Or if you prefer right-clicking, you can drag and drop any of the above python scripts (e.g., `generate_urban_assets.py`) into the Content Browser, right click the asset, and select **Run Editor Utility Python Script**.
@@ -37,7 +38,7 @@ As part of the goal to dynamically generate content, there are Python scripts in
 
 The scripts will:
 - Create `/Game/Art/Models/Forest/`, `/Game/Art/Models/Mountains/`, `/Game/Art/Models/Urban/`, `/Game/Art/Models/Countryside/`, `/Game/Art/Models/Desert/`, `/Game/Art/Models/Beach/`, `/Game/Art/Models/Wetlands/`, `/Game/Art/Models/Character/`, and `/Game/Art/Materials/`.
-- Procedurally generate `SM_PineTree`, `SM_ForestRock`, and `SM_ForestLog` for Forest, `SM_MountainRock`, `SM_MountainCliff`, and `SM_AlpinePlant` for Mountains, `SM_UrbanBuilding`, `SM_UrbanBench`, `SM_UrbanTrafficLight`, and `SM_UrbanParkTree` for Urban, `SM_PalmTree` and `SM_Sandcastle` for Beach, `SM_FarmHouse`, `SM_CountrysideFence`, `SM_Crop`, and `SM_Animal` for Countryside, `SM_WaterBody`, `SM_MarshPlant`, and `SM_WetlandsBridge` for Wetlands, `SM_DesertCactus`, `SM_DesertRock`, and `SM_DesertDune` for Desert, and `SM_Bike` for the Main Bike Character using simple primitive and geometry boolean/noise functions.
+- Procedurally generate `SM_PineTree`, `SM_ForestRock`, and `SM_ForestLog` for Forest, `SM_MountainRock`, `SM_MountainCliff`, and `SM_AlpinePlant` for Mountains, `SM_UrbanBuilding`, `SM_UrbanBench`, `SM_UrbanTrafficLight`, and `SM_UrbanParkTree` for Urban, `SM_PalmTree`, `SM_Sandcastle`, `SM_BeachRock`, and `SM_BeachChair` for Beach, `SM_FarmHouse`, `SM_CountrysideFence`, `SM_Crop`, and `SM_Animal` for Countryside, `SM_WaterBody`, `SM_MarshPlant`, and `SM_WetlandsBridge` for Wetlands, `SM_DesertCactus`, `SM_DesertRock`, and `SM_DesertDune` for Desert, and `SM_Bike` for the Main Bike Character using simple primitive and geometry boolean/noise functions.
 - Procedurally construct master materials like `M_StylizedMaster` and `M_StylizedUrban`, and derived material instances (e.g., `MI_MountainRock`, `MI_UrbanBuilding`, `MI_ForestLog`).
 - Assign these material instances to the corresponding static meshes.
 

--- a/scripts/asset_generation/generate_beach_props.py
+++ b/scripts/asset_generation/generate_beach_props.py
@@ -1,0 +1,133 @@
+import unreal
+import asset_utils
+
+def generate_beach_rock(mesh_path, mat_inst):
+    if unreal.EditorAssetLibrary.does_asset_exist(mesh_path):
+        print(f"Asset already exists: {mesh_path}")
+        return
+
+    dyn_mesh = asset_utils.create_dynamic_mesh()
+    options = unreal.GeometryScriptPrimitiveOptions()
+    primitive_functions = asset_utils.get_geometry_script_primitive_functions()
+    transform = unreal.Transform()
+
+    # Create base box to act as a rock
+    try:
+        primitive_functions.append_box(
+            target_mesh=dyn_mesh,
+            primitive_options=options,
+            transform=transform,
+            dimension_x=130.0,
+            dimension_y=110.0,
+            dimension_z=60.0,
+            steps_x=3,
+            steps_y=3,
+            steps_z=3,
+            origin=unreal.GeometryScriptPrimitiveOriginMode.BASE
+        )
+    except Exception as e:
+        print(f"GeometryScript generation failed: {e}")
+        return
+
+    try:
+        static_mesh = asset_utils.create_static_mesh_from_dynamic_mesh(dyn_mesh, mesh_path)
+        asset_utils.assign_material_to_mesh(static_mesh, mat_inst)
+    except Exception as e:
+        print(f"GeometryScript bake failed: {e}")
+
+def generate_beach_chair(mesh_path, mat_inst):
+    if unreal.EditorAssetLibrary.does_asset_exist(mesh_path):
+        print(f"Asset already exists: {mesh_path}")
+        return
+
+    dyn_mesh = asset_utils.create_dynamic_mesh()
+    options = unreal.GeometryScriptPrimitiveOptions()
+    primitive_functions = asset_utils.get_geometry_script_primitive_functions()
+
+    try:
+        # Seat
+        seat_transform = unreal.Transform()
+        seat_transform.translation = [0.0, 0.0, 30.0]
+        primitive_functions.append_box(
+            target_mesh=dyn_mesh,
+            primitive_options=options,
+            transform=seat_transform,
+            dimension_x=60.0,
+            dimension_y=80.0,
+            dimension_z=5.0,
+            steps_x=1,
+            steps_y=1,
+            steps_z=1,
+            origin=unreal.GeometryScriptPrimitiveOriginMode.CENTER
+        )
+
+        # Backrest
+        backrest_transform = unreal.Transform()
+        backrest_transform.translation = [-30.0, 0.0, 60.0]
+        backrest_transform.rotation = unreal.Rotator(0, 0, -20).quaternion()
+        primitive_functions.append_box(
+            target_mesh=dyn_mesh,
+            primitive_options=options,
+            transform=backrest_transform,
+            dimension_x=5.0,
+            dimension_y=80.0,
+            dimension_z=60.0,
+            steps_x=1,
+            steps_y=1,
+            steps_z=1,
+            origin=unreal.GeometryScriptPrimitiveOriginMode.CENTER
+        )
+    except Exception as e:
+        print(f"GeometryScript generation failed: {e}")
+        return
+
+    create_options = unreal.GeometryScriptCreateNewStaticMeshAssetOptions()
+    try:
+        if hasattr(unreal, "GeometryScriptLibrary_CreateNewStaticMeshAssetFromDynamicMesh"):
+            static_mesh = unreal.GeometryScriptLibrary_CreateNewStaticMeshAssetFromDynamicMesh.create_new_static_mesh_asset_from_dynamic_mesh(
+                dynamic_mesh=dyn_mesh,
+                asset_path_and_name=mesh_path,
+                options=create_options
+            )
+        else:
+            static_mesh = unreal.GeometryScript_AssetUtils.create_new_static_mesh_asset_from_dynamic_mesh(
+                dynamic_mesh=dyn_mesh,
+                asset_path_and_name=mesh_path,
+                options=create_options
+            )
+
+        # Apply material
+        asset_utils.assign_material_to_mesh(static_mesh, mat_inst)
+    except Exception as e:
+        print(f"GeometryScript bake failed: {e}")
+
+def main():
+    base_dir = '/Game/Art/Models/Beach'
+    mat_dir = '/Game/Art/Materials'
+
+    asset_utils.ensure_directory(base_dir)
+    asset_utils.ensure_directory(mat_dir)
+
+    # Use the existing master material created by generate_beach_assets.py
+    master_mat_path = f"{mat_dir}/M_StylizedBeach"
+    master_mat = asset_utils.create_master_material(master_mat_path, default_roughness=0.8, noise_scale=0.05)
+
+    # Create Material Instances for the Rock and Chair
+    rock_mat_path = f"{mat_dir}/MI_BeachRock"
+    rock_mat = asset_utils.create_material_instance(rock_mat_path, master_mat, [0.4, 0.4, 0.4, 1.0], 0.9)
+
+    chair_mat_path = f"{mat_dir}/MI_BeachChair"
+    # A bright color for the beach chair, e.g., cyan/blue
+    chair_mat = asset_utils.create_material_instance(chair_mat_path, master_mat, [0.1, 0.6, 0.8, 1.0], 0.6)
+
+    # Generation
+    rock_mesh_path = f"{base_dir}/SM_BeachRock"
+    generate_beach_rock(rock_mesh_path, rock_mat)
+
+    chair_mesh_path = f"{base_dir}/SM_BeachChair"
+    generate_beach_chair(chair_mesh_path, chair_mat)
+
+    print("Asset generation for new Beach props complete.")
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This PR adds procedural generation pipelines for two new stylized props (`BeachRock` and `BeachChair`) for the Beach biome.

### What
- New python generator script `generate_beach_props.py` which creates the geometry for rocks and chairs and saves them as `.uasset` objects.
- Creation and application of procedural material instances.
- Modified `UBeachPCGSettings` (Header and CPP) to hold references to the generated meshes and layout parameters (`RockDensity` and `ChairChance`).
- Adjusted `GenerateBeachLayout` to scatter these items properly across the terrain using deterministic seeds.
- Updated `ART_PIPELINE.md` with instructions on how to run this generation pass.

### Why
To fulfill the requirement to incrementally populate missing assets in the UE5 project using procedural Python scripts, satisfying the requirement to construct models programmatically rather than manually pushing binary files.

### Verification
- Tested locally by running `./scripts/automation/run-all-tests.sh` locally across Linux/Windows mocked testing environments, verifying no regressions were added and performance boundaries remained intact.
- Verified python syntax and imports (`asset_utils`).

---
*PR created automatically by Jules for task [561860266040170249](https://jules.google.com/task/561860266040170249) started by @zvirb*