### PR TITLE
feat: Add procedurally generated Forest Bush and Mushroom assets to PCG

### DIFF
--- a/Source/BikeAdventure/Systems/AdvancedBiomePCGSettings.cpp
+++ b/Source/BikeAdventure/Systems/AdvancedBiomePCGSettings.cpp
@@ -28,11 +28,15 @@ UForestPCGSettings::UForestPCGSettings()
     TreeDensity = 0.4f; // Lowered to meet 60 FPS constraint
     RockDensity = 0.3f;
     LogDensity = 0.2f;
+    BushDensity = 0.3f; // Added for Forest Extensions
+    MushroomDensity = 0.2f; // Added for Forest Extensions
 
     // Add programmatic assets to arrays
     TreeMeshes.Add(TSoftObjectPtr<UStaticMesh>(FSoftObjectPath(TEXT("/Game/Art/Models/Forest/SM_PineTree.SM_PineTree"))));
     RockMeshes.Add(TSoftObjectPtr<UStaticMesh>(FSoftObjectPath(TEXT("/Game/Art/Models/Forest/SM_ForestRock.SM_ForestRock"))));
     LogMeshes.Add(TSoftObjectPtr<UStaticMesh>(FSoftObjectPath(TEXT("/Game/Art/Models/Forest/SM_ForestLog.SM_ForestLog"))));
+    BushMeshes.Add(TSoftObjectPtr<UStaticMesh>(FSoftObjectPath(TEXT("/Game/Art/Models/Forest/SM_ForestBush.SM_ForestBush"))));
+    MushroomMeshes.Add(TSoftObjectPtr<UStaticMesh>(FSoftObjectPath(TEXT("/Game/Art/Models/Forest/SM_ForestMushroom.SM_ForestMushroom"))));
 }
 
 // Urban PCG Settings
@@ -393,6 +397,56 @@ void FAdvancedBiomeGenerationElement::GenerateForestLayout(FPCGContext* Context,
         ApplyBiomeAttributes(RockPoint, EBiomeType::Forest, TEXT("Rock"));
 
         OutPoints.Add(RockPoint);
+    }
+
+    // Generate bushes
+    int32 NumBushes = FMath::RoundToInt(400.0f * Settings->BushDensity);
+    for (int32 i = 0; i < NumBushes; i++)
+    {
+        FVector Location(
+            Random.FRandRange(-2000.0f, 2000.0f),
+            Random.FRandRange(-2000.0f, 2000.0f),
+            0.0f
+        );
+
+        FRotator Rotation(
+            Random.FRandRange(-10.0f, 10.0f),
+            Random.FRandRange(0.0f, 360.0f),
+            Random.FRandRange(-10.0f, 10.0f)
+        );
+
+        FVector Scale(Random.FRandRange(0.8f, 1.6f));
+
+        FPCGPoint BushPoint = CreateBiomePoint(Location, Rotation, Scale, EBiomeType::Forest, 2);
+        BushPoint.Density = Settings->BushDensity;
+        ApplyBiomeAttributes(BushPoint, EBiomeType::Forest, TEXT("Bush"));
+
+        OutPoints.Add(BushPoint);
+    }
+
+    // Generate mushrooms
+    int32 NumMushrooms = FMath::RoundToInt(300.0f * Settings->MushroomDensity);
+    for (int32 i = 0; i < NumMushrooms; i++)
+    {
+        FVector Location(
+            Random.FRandRange(-2000.0f, 2000.0f),
+            Random.FRandRange(-2000.0f, 2000.0f),
+            0.0f
+        );
+
+        FRotator Rotation(
+            Random.FRandRange(-5.0f, 5.0f),
+            Random.FRandRange(0.0f, 360.0f),
+            Random.FRandRange(-5.0f, 5.0f)
+        );
+
+        FVector Scale(Random.FRandRange(0.4f, 0.9f));
+
+        FPCGPoint MushroomPoint = CreateBiomePoint(Location, Rotation, Scale, EBiomeType::Forest, 3);
+        MushroomPoint.Density = Settings->MushroomDensity;
+        ApplyBiomeAttributes(MushroomPoint, EBiomeType::Forest, TEXT("Mushroom"));
+
+        OutPoints.Add(MushroomPoint);
     }
 }
 

--- a/Source/BikeAdventure/Systems/AdvancedBiomePCGSettings.h
+++ b/Source/BikeAdventure/Systems/AdvancedBiomePCGSettings.h
@@ -73,6 +73,14 @@ public:
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "Forest Generation", meta = (ClampMin = "0.0", ClampMax = "1.0"))
     float LogDensity;
 
+    // Bush density
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "Forest Generation", meta = (ClampMin = "0.0", ClampMax = "1.0"))
+    float BushDensity;
+
+    // Mushroom density
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "Forest Generation", meta = (ClampMin = "0.0", ClampMax = "1.0"))
+    float MushroomDensity;
+
     // Tree meshes
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "Forest Assets")
     TArray<TSoftObjectPtr<UStaticMesh>> TreeMeshes;
@@ -84,6 +92,14 @@ public:
     // Log meshes
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "Forest Assets")
     TArray<TSoftObjectPtr<UStaticMesh>> LogMeshes;
+
+    // Bush meshes
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "Forest Assets")
+    TArray<TSoftObjectPtr<UStaticMesh>> BushMeshes;
+
+    // Mushroom meshes
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "Forest Assets")
+    TArray<TSoftObjectPtr<UStaticMesh>> MushroomMeshes;
 };
 
 /**

--- a/docs/ART_PIPELINE.md
+++ b/docs/ART_PIPELINE.md
@@ -30,6 +30,7 @@ As part of the goal to dynamically generate content, there are Python scripts in
    exec(open("C:/Path/To/Your/Repo/scripts/asset_generation/generate_desert_assets.py").read())
    exec(open("C:/Path/To/Your/Repo/scripts/asset_generation/generate_beach_assets.py").read())
    exec(open("C:/Path/To/Your/Repo/scripts/asset_generation/generate_beach_props.py").read())
+   exec(open("C:/Path/To/Your/Repo/scripts/asset_generation/generate_forest_props.py").read())
    exec(open("C:/Path/To/Your/Repo/scripts/asset_generation/generate_bike_assets.py").read())
    ```
    Or if you prefer right-clicking, you can drag and drop any of the above python scripts (e.g., `generate_urban_assets.py`) into the Content Browser, right click the asset, and select **Run Editor Utility Python Script**.
@@ -38,8 +39,8 @@ As part of the goal to dynamically generate content, there are Python scripts in
 
 The scripts will:
 - Create `/Game/Art/Models/Forest/`, `/Game/Art/Models/Mountains/`, `/Game/Art/Models/Urban/`, `/Game/Art/Models/Countryside/`, `/Game/Art/Models/Desert/`, `/Game/Art/Models/Beach/`, `/Game/Art/Models/Wetlands/`, `/Game/Art/Models/Character/`, and `/Game/Art/Materials/`.
-- Procedurally generate `SM_PineTree`, `SM_ForestRock`, and `SM_ForestLog` for Forest, `SM_MountainRock`, `SM_MountainCliff`, and `SM_AlpinePlant` for Mountains, `SM_UrbanBuilding`, `SM_UrbanBench`, `SM_UrbanTrafficLight`, and `SM_UrbanParkTree` for Urban, `SM_PalmTree`, `SM_Sandcastle`, `SM_BeachRock`, and `SM_BeachChair` for Beach, `SM_FarmHouse`, `SM_CountrysideFence`, `SM_Crop`, and `SM_Animal` for Countryside, `SM_WaterBody`, `SM_MarshPlant`, and `SM_WetlandsBridge` for Wetlands, `SM_DesertCactus`, `SM_DesertRock`, and `SM_DesertDune` for Desert, and `SM_Bike` for the Main Bike Character using simple primitive and geometry boolean/noise functions.
-- Procedurally construct master materials like `M_StylizedMaster` and `M_StylizedUrban`, and derived material instances (e.g., `MI_MountainRock`, `MI_UrbanBuilding`, `MI_ForestLog`).
+- Procedurally generate `SM_PineTree`, `SM_ForestRock`, `SM_ForestLog`, `SM_ForestBush`, and `SM_ForestMushroom` for Forest, `SM_MountainRock`, `SM_MountainCliff`, and `SM_AlpinePlant` for Mountains, `SM_UrbanBuilding`, `SM_UrbanBench`, `SM_UrbanTrafficLight`, and `SM_UrbanParkTree` for Urban, `SM_PalmTree`, `SM_Sandcastle`, `SM_BeachRock`, and `SM_BeachChair` for Beach, `SM_FarmHouse`, `SM_CountrysideFence`, `SM_Crop`, and `SM_Animal` for Countryside, `SM_WaterBody`, `SM_MarshPlant`, and `SM_WetlandsBridge` for Wetlands, `SM_DesertCactus`, `SM_DesertRock`, and `SM_DesertDune` for Desert, and `SM_Bike` for the Main Bike Character using simple primitive and geometry boolean/noise functions.
+- Procedurally construct master materials like `M_StylizedMaster` and `M_StylizedUrban`, and derived material instances (e.g., `MI_MountainRock`, `MI_UrbanBuilding`, `MI_ForestLog`, `MI_ForestBush`, `MI_ForestMushroom`).
 - Assign these material instances to the corresponding static meshes.
 
 These meshes are then automatically linked into the PCG spawning logic for their respective biomes via C++ (e.g., `UMountainPCGSettings` and `UUrbanPCGSettings`).

--- a/scripts/asset_generation/generate_forest_props.py
+++ b/scripts/asset_generation/generate_forest_props.py
@@ -1,0 +1,223 @@
+import unreal
+import asset_utils
+
+def generate_forest_bush(mesh_path, mat_inst):
+    if unreal.EditorAssetLibrary.does_asset_exist(mesh_path):
+        print(f"Asset already exists: {mesh_path}")
+        return
+
+    try:
+        dyn_mesh = unreal.GeometryScriptLibrary_CreateNewDynamicMesh.create_new_dynamic_mesh()
+    except AttributeError:
+        try:
+            dyn_mesh = unreal.GeometryScript_AssetUtils.create_new_dynamic_mesh()
+        except AttributeError:
+            dyn_mesh = unreal.DynamicMesh()
+
+    options = unreal.GeometryScriptPrimitiveOptions()
+
+    try:
+        if hasattr(unreal, "GeometryScriptLibrary_MeshPrimitiveFunctions"):
+            # Bush core
+            core_transform = unreal.Transform()
+            unreal.GeometryScriptLibrary_MeshPrimitiveFunctions.append_sphere(
+                target_mesh=dyn_mesh,
+                primitive_options=options,
+                transform=core_transform,
+                radius=40.0,
+                steps_x=10,
+                steps_y=10,
+                origin=unreal.GeometryScriptPrimitiveOriginMode.BASE
+            )
+            # Add some variations to make it look bushy
+            for i in range(3):
+                part_transform = unreal.Transform()
+                part_transform.translation = [(i - 1) * 20.0, (i % 2) * 20.0, 10.0]
+                unreal.GeometryScriptLibrary_MeshPrimitiveFunctions.append_sphere(
+                    target_mesh=dyn_mesh,
+                    primitive_options=options,
+                    transform=part_transform,
+                    radius=25.0,
+                    steps_x=8,
+                    steps_y=8,
+                    origin=unreal.GeometryScriptPrimitiveOriginMode.BASE
+                )
+        else:
+            # Bush core
+            core_transform = unreal.Transform()
+            unreal.GeometryScript_MeshPrimitiveFunctions.append_sphere(
+                target_mesh=dyn_mesh,
+                primitive_options=options,
+                transform=core_transform,
+                radius=40.0,
+                steps_x=10,
+                steps_y=10,
+                origin=unreal.GeometryScriptPrimitiveOriginMode.BASE
+            )
+            # Add some variations to make it look bushy
+            for i in range(3):
+                part_transform = unreal.Transform()
+                part_transform.translation = [(i - 1) * 20.0, (i % 2) * 20.0, 10.0]
+                unreal.GeometryScript_MeshPrimitiveFunctions.append_sphere(
+                    target_mesh=dyn_mesh,
+                    primitive_options=options,
+                    transform=part_transform,
+                    radius=25.0,
+                    steps_x=8,
+                    steps_y=8,
+                    origin=unreal.GeometryScriptPrimitiveOriginMode.BASE
+                )
+    except Exception as e:
+        print(f"GeometryScript generation failed: {e}")
+        return
+
+    create_options = unreal.GeometryScriptCreateNewStaticMeshAssetOptions()
+    try:
+        if hasattr(unreal, "GeometryScriptLibrary_CreateNewStaticMeshAssetFromDynamicMesh"):
+            static_mesh = unreal.GeometryScriptLibrary_CreateNewStaticMeshAssetFromDynamicMesh.create_new_static_mesh_asset_from_dynamic_mesh(
+                dynamic_mesh=dyn_mesh,
+                asset_path_and_name=mesh_path,
+                options=create_options
+            )
+        else:
+            static_mesh = unreal.GeometryScript_AssetUtils.create_new_static_mesh_asset_from_dynamic_mesh(
+                dynamic_mesh=dyn_mesh,
+                asset_path_and_name=mesh_path,
+                options=create_options
+            )
+
+        # Apply material
+        asset_utils.assign_material_to_mesh(static_mesh, mat_inst)
+    except Exception as e:
+        print(f"GeometryScript bake failed: {e}")
+
+def generate_forest_mushroom(mesh_path, mat_inst):
+    if unreal.EditorAssetLibrary.does_asset_exist(mesh_path):
+        print(f"Asset already exists: {mesh_path}")
+        return
+
+    try:
+        dyn_mesh = unreal.GeometryScriptLibrary_CreateNewDynamicMesh.create_new_dynamic_mesh()
+    except AttributeError:
+        try:
+            dyn_mesh = unreal.GeometryScript_AssetUtils.create_new_dynamic_mesh()
+        except AttributeError:
+            dyn_mesh = unreal.DynamicMesh()
+
+    options = unreal.GeometryScriptPrimitiveOptions()
+
+    try:
+        if hasattr(unreal, "GeometryScriptLibrary_MeshPrimitiveFunctions"):
+            # Stem
+            stem_transform = unreal.Transform()
+            unreal.GeometryScriptLibrary_MeshPrimitiveFunctions.append_cylinder(
+                target_mesh=dyn_mesh,
+                primitive_options=options,
+                transform=stem_transform,
+                radius=5.0,
+                height=20.0,
+                radial_steps=8,
+                height_steps=1,
+                capped=True,
+                origin=unreal.GeometryScriptPrimitiveOriginMode.BASE
+            )
+            # Cap
+            cap_transform = unreal.Transform()
+            cap_transform.translation = [0.0, 0.0, 15.0]
+            unreal.GeometryScriptLibrary_MeshPrimitiveFunctions.append_cone(
+                target_mesh=dyn_mesh,
+                primitive_options=options,
+                transform=cap_transform,
+                base_radius=15.0,
+                top_radius=2.0,
+                height=10.0,
+                radial_steps=12,
+                height_steps=1,
+                capped=True,
+                origin=unreal.GeometryScriptPrimitiveOriginMode.BASE
+            )
+        else:
+            # Stem
+            stem_transform = unreal.Transform()
+            unreal.GeometryScript_MeshPrimitiveFunctions.append_cylinder(
+                target_mesh=dyn_mesh,
+                primitive_options=options,
+                transform=stem_transform,
+                radius=5.0,
+                height=20.0,
+                radial_steps=8,
+                height_steps=1,
+                capped=True,
+                origin=unreal.GeometryScriptPrimitiveOriginMode.BASE
+            )
+            # Cap
+            cap_transform = unreal.Transform()
+            cap_transform.translation = [0.0, 0.0, 15.0]
+            unreal.GeometryScript_MeshPrimitiveFunctions.append_cone(
+                target_mesh=dyn_mesh,
+                primitive_options=options,
+                transform=cap_transform,
+                base_radius=15.0,
+                top_radius=2.0,
+                height=10.0,
+                radial_steps=12,
+                height_steps=1,
+                capped=True,
+                origin=unreal.GeometryScriptPrimitiveOriginMode.BASE
+            )
+    except Exception as e:
+        print(f"GeometryScript generation failed: {e}")
+        return
+
+    create_options = unreal.GeometryScriptCreateNewStaticMeshAssetOptions()
+    try:
+        if hasattr(unreal, "GeometryScriptLibrary_CreateNewStaticMeshAssetFromDynamicMesh"):
+            static_mesh = unreal.GeometryScriptLibrary_CreateNewStaticMeshAssetFromDynamicMesh.create_new_static_mesh_asset_from_dynamic_mesh(
+                dynamic_mesh=dyn_mesh,
+                asset_path_and_name=mesh_path,
+                options=create_options
+            )
+        else:
+            static_mesh = unreal.GeometryScript_AssetUtils.create_new_static_mesh_asset_from_dynamic_mesh(
+                dynamic_mesh=dyn_mesh,
+                asset_path_and_name=mesh_path,
+                options=create_options
+            )
+
+        # Apply material
+        asset_utils.assign_material_to_mesh(static_mesh, mat_inst)
+    except Exception as e:
+        print(f"GeometryScript bake failed: {e}")
+
+
+def main():
+    base_dir = '/Game/Art/Models/Forest'
+    mat_dir = '/Game/Art/Materials'
+
+    asset_utils.ensure_directory(base_dir)
+    asset_utils.ensure_directory(mat_dir)
+
+    # Note: Use the existing master material if present, otherwise create a new one.
+    master_mat_path = f"{mat_dir}/M_StylizedForest"
+    master_mat = asset_utils.create_master_material(master_mat_path, default_roughness=0.8, noise_scale=0.05)
+
+    # Procedural Material Instances
+    bush_mat_path = f"{mat_dir}/MI_ForestBush"
+    # Darker green for bush
+    bush_mat = asset_utils.create_material_instance(bush_mat_path, master_mat, [0.08, 0.35, 0.08, 1.0], 0.9)
+
+    mushroom_mat_path = f"{mat_dir}/MI_ForestMushroom"
+    # Red with some brightness for the mushroom
+    mushroom_mat = asset_utils.create_material_instance(mushroom_mat_path, master_mat, [0.8, 0.1, 0.1, 1.0], 0.6)
+
+    # Programmatic 3D Modeling
+    bush_mesh_path = f"{base_dir}/SM_ForestBush"
+    generate_forest_bush(bush_mesh_path, bush_mat)
+
+    mushroom_mesh_path = f"{base_dir}/SM_ForestMushroom"
+    generate_forest_mushroom(mushroom_mesh_path, mushroom_mat)
+
+    print("Asset generation for Forest biome extensions complete.")
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This PR extends the Forest biome by programmatically generating new `Bush` and `Mushroom` assets.

**Changes:**
1. Created `scripts/asset_generation/generate_forest_props.py` to procedurally construct `SM_ForestBush` and `SM_ForestMushroom` meshes and assign them `MI_ForestBush` and `MI_ForestMushroom` materials derived from `M_StylizedForest` using `asset_utils.py`.
2. Updated C++ settings in `UForestPCGSettings` (`AdvancedBiomePCGSettings.h` and `.cpp`) to add configurable `BushDensity` and `MushroomDensity` properties, along with their respective `TSoftObjectPtr<UStaticMesh>` arrays for the PCG spawner.
3. Updated `FAdvancedBiomeGenerationElement::GenerateForestLayout` to programmatically scatter the newly generated bushes and mushrooms across the forest biome.
4. Updated `docs/ART_PIPELINE.md` to document the new generation script and its output assets.

---
*PR created automatically by Jules for task [677322368569549791](https://jules.google.com/task/677322368569549791) started by @zvirb*