### PR TITLE
✨ [art pipeline] Add Desert biome procedural extensions (Shrub, Oasis)

### DIFF
--- a/Source/BikeAdventure/Systems/AdvancedBiomePCGSettings.cpp
+++ b/Source/BikeAdventure/Systems/AdvancedBiomePCGSettings.cpp
@@ -108,11 +108,15 @@ UDesertPCGSettings::UDesertPCGSettings()
     RockDensity = 0.3f;
     DuneVariation = 1.0f;
     OasisChance = 0.05f;
+    ShrubDensity = 0.5f;
 
     // Add programmatic assets to arrays
     CactusMeshes.Add(TSoftObjectPtr<UStaticMesh>(FSoftObjectPath(TEXT("/Game/Art/Models/Desert/SM_DesertCactus.SM_DesertCactus"))));
     RockMeshes.Add(TSoftObjectPtr<UStaticMesh>(FSoftObjectPath(TEXT("/Game/Art/Models/Desert/SM_DesertRock.SM_DesertRock"))));
     DuneMeshes.Add(TSoftObjectPtr<UStaticMesh>(FSoftObjectPath(TEXT("/Game/Art/Models/Desert/SM_DesertDune.SM_DesertDune"))));
+    ShrubMeshes.Add(TSoftObjectPtr<UStaticMesh>(FSoftObjectPath(TEXT("/Game/Art/Models/Desert/SM_DesertShrub.SM_DesertShrub"))));
+    OasisPalmTreeMeshes.Add(TSoftObjectPtr<UStaticMesh>(FSoftObjectPath(TEXT("/Game/Art/Models/Desert/SM_OasisPalmTree.SM_OasisPalmTree"))));
+    OasisWaterMeshes.Add(TSoftObjectPtr<UStaticMesh>(FSoftObjectPath(TEXT("/Game/Art/Models/Desert/SM_OasisWater.SM_OasisWater"))));
 }
 
 // Wetlands PCG Settings
@@ -1073,6 +1077,75 @@ void FAdvancedBiomeGenerationElement::GenerateDesertLayout(FPCGContext* Context,
         ApplyBiomeAttributes(RockPoint, EBiomeType::Desert, TEXT("Rock"));
 
         OutPoints.Add(RockPoint);
+    }
+
+    // Generate shrubs
+    int32 NumShrubs = FMath::RoundToInt(300.0f * Settings->ShrubDensity);
+    for (int32 i = 0; i < NumShrubs; i++)
+    {
+        FVector Location(
+            Random.FRandRange(-2000.0f, 2000.0f),
+            Random.FRandRange(-2000.0f, 2000.0f),
+            0.0f
+        );
+
+        FRotator Rotation(
+            Random.FRandRange(-5.0f, 5.0f),
+            Random.FRandRange(0.0f, 360.0f),
+            Random.FRandRange(-5.0f, 5.0f)
+        );
+
+        FVector Scale(Random.FRandRange(0.6f, 1.2f));
+
+        FPCGPoint ShrubPoint = CreateBiomePoint(Location, Rotation, Scale, EBiomeType::Desert, 2);
+        ShrubPoint.Density = Settings->ShrubDensity;
+        ApplyBiomeAttributes(ShrubPoint, EBiomeType::Desert, TEXT("DesertShrub"));
+
+        OutPoints.Add(ShrubPoint);
+    }
+
+    // Generate oasis
+    if (Random.FRand() < Settings->OasisChance)
+    {
+        FVector OasisCenter(
+            Random.FRandRange(-1500.0f, 1500.0f),
+            Random.FRandRange(-1500.0f, 1500.0f),
+            0.0f
+        );
+
+        // Oasis water pool
+        FRotator WaterRotation(0.0f, Random.FRandRange(0.0f, 360.0f), 0.0f);
+        FVector WaterScale(Random.FRandRange(0.8f, 1.5f));
+
+        FPCGPoint WaterPoint = CreateBiomePoint(OasisCenter, WaterRotation, WaterScale, EBiomeType::Desert, 4);
+        ApplyBiomeAttributes(WaterPoint, EBiomeType::Desert, TEXT("OasisWater"));
+
+        OutPoints.Add(WaterPoint);
+
+        // Oasis palm trees
+        int32 NumPalmTrees = Random.RandRange(3, 8);
+        for (int32 i = 0; i < NumPalmTrees; i++)
+        {
+            float Angle = (2.0f * PI * i) / NumPalmTrees;
+            FVector PalmLocation = OasisCenter + FVector(
+                FMath::Cos(Angle) * 450.0f * WaterScale.X + Random.FRandRange(-50.0f, 50.0f),
+                FMath::Sin(Angle) * 450.0f * WaterScale.Y + Random.FRandRange(-50.0f, 50.0f),
+                0.0f
+            );
+
+            FRotator PalmRotation(
+                Random.FRandRange(-10.0f, 10.0f),
+                Random.FRandRange(0.0f, 360.0f),
+                Random.FRandRange(-10.0f, 10.0f)
+            );
+
+            FVector PalmScale(Random.FRandRange(0.8f, 1.2f));
+
+            FPCGPoint PalmPoint = CreateBiomePoint(PalmLocation, PalmRotation, PalmScale, EBiomeType::Desert, 3);
+            ApplyBiomeAttributes(PalmPoint, EBiomeType::Desert, TEXT("OasisPalmTree"));
+
+            OutPoints.Add(PalmPoint);
+        }
     }
 }
 

--- a/Source/BikeAdventure/Systems/AdvancedBiomePCGSettings.h
+++ b/Source/BikeAdventure/Systems/AdvancedBiomePCGSettings.h
@@ -385,6 +385,10 @@ public:
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "Desert Generation", meta = (ClampMin = "0.0", ClampMax = "1.0"))
     float OasisChance;
 
+    // Shrub density
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "Desert Generation", meta = (ClampMin = "0.0", ClampMax = "1.0"))
+    float ShrubDensity;
+
     // Cactus and vegetation meshes
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "Desert Assets")
     TArray<TSoftObjectPtr<UStaticMesh>> CactusMeshes;
@@ -396,6 +400,18 @@ public:
     // Dune meshes
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "Desert Assets")
     TArray<TSoftObjectPtr<UStaticMesh>> DuneMeshes;
+
+    // Shrub meshes
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "Desert Assets")
+    TArray<TSoftObjectPtr<UStaticMesh>> ShrubMeshes;
+
+    // Oasis palm tree meshes
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "Desert Assets")
+    TArray<TSoftObjectPtr<UStaticMesh>> OasisPalmTreeMeshes;
+
+    // Oasis water pool meshes
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "Desert Assets")
+    TArray<TSoftObjectPtr<UStaticMesh>> OasisWaterMeshes;
 };
 
 /**

--- a/docs/ART_PIPELINE.md
+++ b/docs/ART_PIPELINE.md
@@ -30,6 +30,7 @@ As part of the goal to dynamically generate content, there are Python scripts in
    exec(open("C:/Path/To/Your/Repo/scripts/asset_generation/generate_wetlands_assets.py").read())
    exec(open("C:/Path/To/Your/Repo/scripts/asset_generation/generate_wetlands_extensions.py").read())
    exec(open("C:/Path/To/Your/Repo/scripts/asset_generation/generate_desert_assets.py").read())
+   exec(open("C:/Path/To/Your/Repo/scripts/asset_generation/generate_desert_extensions.py").read())
    exec(open("C:/Path/To/Your/Repo/scripts/asset_generation/generate_beach_assets.py").read())
    exec(open("C:/Path/To/Your/Repo/scripts/asset_generation/generate_beach_props.py").read())
    exec(open("C:/Path/To/Your/Repo/scripts/asset_generation/generate_forest_props.py").read())
@@ -43,7 +44,7 @@ As part of the goal to dynamically generate content, there are Python scripts in
 
 The scripts will:
 - Create `/Game/Art/Models/Forest/`, `/Game/Art/Models/Mountains/`, `/Game/Art/Models/Urban/`, `/Game/Art/Models/Countryside/`, `/Game/Art/Models/Desert/`, `/Game/Art/Models/Beach/`, `/Game/Art/Models/Wetlands/`, `/Game/Art/Models/Character/`, and `/Game/Art/Materials/`.
-- Procedurally generate `SM_PineTree`, `SM_ForestRock`, `SM_ForestLog`, `SM_ForestBush`, and `SM_ForestMushroom` for Forest, `SM_MountainRock`, `SM_MountainCliff`, and `SM_AlpinePlant` for Mountains, `SM_UrbanBuilding`, `SM_UrbanBench`, `SM_UrbanTrafficLight`, `SM_UrbanParkTree`, `SM_UrbanTrashCan`, `SM_UrbanBusStop`, and `SM_UrbanBicycleRack` for Urban, `SM_PalmTree`, `SM_Sandcastle`, `SM_BeachRock`, and `SM_BeachChair` for Beach, `SM_FarmHouse`, `SM_CountrysideFence`, `SM_Crop`, and `SM_Animal` for Countryside, `SM_WaterBody`, `SM_MarshPlant`, and `SM_WetlandsBridge` for Wetlands, `SM_DesertCactus`, `SM_DesertRock`, and `SM_DesertDune` for Desert, and `SM_Bike` for the Main Bike Character using simple primitive and geometry boolean/noise functions.
+- Procedurally generate `SM_PineTree`, `SM_ForestRock`, `SM_ForestLog`, `SM_ForestBush`, and `SM_ForestMushroom` for Forest, `SM_MountainRock`, `SM_MountainCliff`, and `SM_AlpinePlant` for Mountains, `SM_UrbanBuilding`, `SM_UrbanBench`, `SM_UrbanTrafficLight`, `SM_UrbanParkTree`, `SM_UrbanTrashCan`, `SM_UrbanBusStop`, and `SM_UrbanBicycleRack` for Urban, `SM_PalmTree`, `SM_Sandcastle`, `SM_BeachRock`, and `SM_BeachChair` for Beach, `SM_FarmHouse`, `SM_CountrysideFence`, `SM_Crop`, and `SM_Animal` for Countryside, `SM_WaterBody`, `SM_MarshPlant`, and `SM_WetlandsBridge` for Wetlands, `SM_DesertCactus`, `SM_DesertRock`, `SM_DesertDune`, `SM_DesertShrub`, `SM_OasisPalmTree`, and `SM_OasisWater` for Desert, and `SM_Bike` for the Main Bike Character using simple primitive and geometry boolean/noise functions.
 - Procedurally construct master materials like `M_StylizedMaster` and `M_StylizedUrban`, and derived material instances (e.g., `MI_MountainRock`, `MI_UrbanBuilding`, `MI_ForestLog`, `MI_ForestBush`, `MI_ForestMushroom`).
 - Assign these material instances to the corresponding static meshes.
 

--- a/scripts/asset_generation/generate_desert_extensions.py
+++ b/scripts/asset_generation/generate_desert_extensions.py
@@ -1,0 +1,175 @@
+import unreal
+import asset_utils
+
+def generate_desert_shrub(mesh_path, mat_inst):
+    if unreal.EditorAssetLibrary.does_asset_exist(mesh_path):
+        print(f"Asset already exists: {mesh_path}")
+        return
+
+    dyn_mesh = asset_utils.create_dynamic_mesh()
+    options = unreal.GeometryScriptPrimitiveOptions()
+    primitive_functions = asset_utils.get_geometry_script_primitive_functions()
+    transform = unreal.Transform()
+
+    try:
+        # Create base spherical bush for shrub
+        primitive_functions.append_sphere(
+            target_mesh=dyn_mesh,
+            primitive_options=options,
+            transform=transform,
+            radius=40.0,
+            steps_x=8,
+            steps_y=8,
+            origin=unreal.GeometryScriptPrimitiveOriginMode.BASE
+        )
+
+        # Add a couple of smaller spheres to make it irregular
+        blob1 = unreal.Transform()
+        blob1.translation = [20.0, 15.0, 10.0]
+        primitive_functions.append_sphere(
+            target_mesh=dyn_mesh,
+            primitive_options=options,
+            transform=blob1,
+            radius=25.0,
+            steps_x=6,
+            steps_y=6,
+            origin=unreal.GeometryScriptPrimitiveOriginMode.BASE
+        )
+
+        blob2 = unreal.Transform()
+        blob2.translation = [-15.0, -20.0, 5.0]
+        primitive_functions.append_sphere(
+            target_mesh=dyn_mesh,
+            primitive_options=options,
+            transform=blob2,
+            radius=30.0,
+            steps_x=6,
+            steps_y=6,
+            origin=unreal.GeometryScriptPrimitiveOriginMode.BASE
+        )
+    except Exception as e:
+        print(f"GeometryScript generation failed: {e}")
+        return
+
+    try:
+        static_mesh = asset_utils.create_static_mesh_from_dynamic_mesh(dyn_mesh, mesh_path)
+        asset_utils.assign_material_to_mesh(static_mesh, mat_inst)
+    except Exception as e:
+        print(f"GeometryScript bake failed: {e}")
+
+def generate_oasis_palm_tree(mesh_path, mat_inst):
+    if unreal.EditorAssetLibrary.does_asset_exist(mesh_path):
+        print(f"Asset already exists: {mesh_path}")
+        return
+
+    dyn_mesh = asset_utils.create_dynamic_mesh()
+    options = unreal.GeometryScriptPrimitiveOptions()
+    primitive_functions = asset_utils.get_geometry_script_primitive_functions()
+    transform = unreal.Transform()
+
+    try:
+        # Trunk
+        primitive_functions.append_cylinder(
+            target_mesh=dyn_mesh,
+            primitive_options=options,
+            transform=transform,
+            radius=15.0,
+            height=300.0,
+            radial_steps=8,
+            height_steps=1,
+            capped=True,
+            origin=unreal.GeometryScriptPrimitiveOriginMode.BASE
+        )
+
+        # Canopy / Leaves
+        canopy_transform = unreal.Transform()
+        canopy_transform.translation = [0.0, 0.0, 280.0]
+        primitive_functions.append_sphere(
+            target_mesh=dyn_mesh,
+            primitive_options=options,
+            transform=canopy_transform,
+            radius=120.0,
+            steps_x=10,
+            steps_y=10,
+            origin=unreal.GeometryScriptPrimitiveOriginMode.BASE
+        )
+    except Exception as e:
+        print(f"GeometryScript generation failed: {e}")
+        return
+
+    try:
+        static_mesh = asset_utils.create_static_mesh_from_dynamic_mesh(dyn_mesh, mesh_path)
+        asset_utils.assign_material_to_mesh(static_mesh, mat_inst)
+    except Exception as e:
+        print(f"GeometryScript bake failed: {e}")
+
+def generate_oasis_water(mesh_path, mat_inst):
+    if unreal.EditorAssetLibrary.does_asset_exist(mesh_path):
+        print(f"Asset already exists: {mesh_path}")
+        return
+
+    dyn_mesh = asset_utils.create_dynamic_mesh()
+    options = unreal.GeometryScriptPrimitiveOptions()
+    primitive_functions = asset_utils.get_geometry_script_primitive_functions()
+    transform = unreal.Transform()
+
+    try:
+        # A simple flat disc/cylinder for the oasis water pool
+        primitive_functions.append_cylinder(
+            target_mesh=dyn_mesh,
+            primitive_options=options,
+            transform=transform,
+            radius=400.0,
+            height=10.0,
+            radial_steps=16,
+            height_steps=1,
+            capped=True,
+            origin=unreal.GeometryScriptPrimitiveOriginMode.BASE
+        )
+    except Exception as e:
+        print(f"GeometryScript generation failed: {e}")
+        return
+
+    try:
+        static_mesh = asset_utils.create_static_mesh_from_dynamic_mesh(dyn_mesh, mesh_path)
+        asset_utils.assign_material_to_mesh(static_mesh, mat_inst)
+    except Exception as e:
+        print(f"GeometryScript bake failed: {e}")
+
+def main():
+    base_dir = '/Game/Art/Models/Desert'
+    mat_dir = '/Game/Art/Materials'
+
+    asset_utils.ensure_directory(base_dir)
+    asset_utils.ensure_directory(mat_dir)
+
+    # Procedural Material Generation
+    master_mat_path = f"{mat_dir}/M_StylizedDesert"
+    # We assume master_mat exists from previous run, but we can recreate or just get it.
+    # For safety, we will just call create_master_material which should be idempotent or just return it.
+    master_mat = asset_utils.create_master_material(master_mat_path)
+
+    # Procedural Material Instances
+    shrub_mat_path = f"{mat_dir}/MI_DesertShrub"
+    shrub_mat = asset_utils.create_material_instance(shrub_mat_path, master_mat, [0.4, 0.5, 0.2, 1.0], 0.8) # Dry green
+
+    palm_mat_path = f"{mat_dir}/MI_OasisPalm"
+    palm_mat = asset_utils.create_material_instance(palm_mat_path, master_mat, [0.2, 0.6, 0.2, 1.0], 0.7) # Brighter green for oasis
+
+    water_mat_path = f"{mat_dir}/MI_OasisWater"
+    water_mat = asset_utils.create_material_instance(water_mat_path, master_mat, [0.1, 0.5, 0.8, 1.0], 0.1) # Blue, low roughness
+
+    # Programmatic 3D Modeling
+    shrub_mesh_path = f"{base_dir}/SM_DesertShrub"
+    generate_desert_shrub(shrub_mesh_path, shrub_mat)
+
+    palm_mesh_path = f"{base_dir}/SM_OasisPalmTree"
+    generate_oasis_palm_tree(palm_mesh_path, palm_mat)
+
+    water_mesh_path = f"{base_dir}/SM_OasisWater"
+    generate_oasis_water(water_mesh_path, water_mat)
+
+    print("Asset generation for Desert extensions complete.")
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This PR incrementally builds upon the procedural art pipeline by adding extensions to the Desert biome.

It introduces a new Python script to dynamically generate a stylized Shrub, an Oasis Palm Tree, and an Oasis Water pool. The C++ PCG Settings classes have been updated to scatter these new assets, making the Desert biome feel more alive with rare oases.

### What
- `scripts/asset_generation/generate_desert_extensions.py` using Unreal Geometry Scripting.
- Modified `AdvancedBiomePCGSettings.h` and `.cpp`.
- Updated `ART_PIPELINE.md`.

### Why
- The Desert biome previously only contained rocks, cacti, and dunes. This adds low-lying foliage (shrubs) and rare landmarks (oases) as requested.

### Verification
- Code review approved.
- Python syntax verified.
- C++ logic integrates seamlessly into the existing PCG generation elements.

---
*PR created automatically by Jules for task [1918359966629602908](https://jules.google.com/task/1918359966629602908) started by @zvirb*