### PR TITLE
🔒 [security fix] Replace weak MD5 hash with SHA-256

### DIFF
--- a/.github/workflows/ci-cd-multiplatform.yml
+++ b/.github/workflows/ci-cd-multiplatform.yml
@@ -331,7 +331,7 @@ jobs:
           find artifacts/ -type f -name "*.tar.gz" -o -name "*.zip" | while read file; do
             echo "✓ Found build package: $file"
             echo "  Size: $(du -h "$file" | cut -f1)"
-            echo "  MD5: $(md5sum "$file" | cut -d' ' -f1)"
+            echo "  SHA-256: $(sha256sum "$file" | cut -d' ' -f1)"
           done
 
       - name: Run Deployment Verification

--- a/scripts/automation/deployment-verification.py
+++ b/scripts/automation/deployment-verification.py
@@ -236,10 +236,10 @@ class DeploymentValidator:
             except Exception as e:
                 validation_result["warnings"].append(f"Could not extract version info: {e}")
                 
-            # Calculate MD5 hash for integrity
+            # Calculate SHA-256 hash for integrity
             try:
-                md5_hash = self.calculate_file_hash(executable_path)
-                validation_result["details"]["md5_hash"] = md5_hash
+                sha256_hash = self.calculate_file_hash(executable_path)
+                validation_result["details"]["sha256_hash"] = sha256_hash
             except Exception as e:
                 validation_result["warnings"].append(f"Could not calculate hash: {e}")
                 
@@ -302,7 +302,7 @@ class DeploymentValidator:
                 
                 # Calculate hash for integrity
                 try:
-                    pak_info["md5_hash"] = self.calculate_file_hash(pak_file)
+                    pak_info["sha256_hash"] = self.calculate_file_hash(pak_file)
                 except Exception as e:
                     pak_info["hash_error"] = str(e)
                     
@@ -655,13 +655,13 @@ class DeploymentValidator:
         return None
         
     def calculate_file_hash(self, file_path: Path) -> str:
-        """Calculate MD5 hash of a file"""
-        hash_md5 = hashlib.md5()
+        """Calculate SHA-256 hash of a file"""
+        hash_sha256 = hashlib.sha256()
         with open(file_path, "rb") as f:
             # Read in chunks to handle large files
             for chunk in iter(lambda: f.read(4096), b""):
-                hash_md5.update(chunk)
-        return hash_md5.hexdigest()
+                hash_sha256.update(chunk)
+        return hash_sha256.hexdigest()
         
     def run_comprehensive_validation(self) -> bool:
         """Run all validation tests"""


### PR DESCRIPTION
### 🎯 What: The vulnerability fixed
Replaced the use of MD5 (a weak hash algorithm) with SHA-256 in the project's deployment verification scripts and CI/CD workflows.

### ⚠️ Risk: The potential impact if left unfixed
MD5 is cryptographically broken and vulnerable to collision attacks. While used here primarily for integrity checks, using weak hashes is poor security practice and could potentially be exploited to bypass integrity validation if an attacker can generate a malicious file with a matching MD5 hash.

### 🛡️ Solution: How the fix addresses the vulnerability
- Modified `scripts/automation/deployment-verification.py` to use `hashlib.sha256()` instead of `hashlib.md5()`.
- Updated all associated variable names and JSON report keys to reflect the use of SHA-256.
- Updated the GitHub Actions workflow `.github/workflows/ci-cd-multiplatform.yml` to use the `sha256sum` command-line utility instead of `md5sum`.
- Verified the fix with a local Python script that confirmed SHA-256 generation.


---
*PR created automatically by Jules for task [15531381529277028947](https://jules.google.com/task/15531381529277028947) started by @zvirb*