### PR TITLE
⚡ [consolidated component registration]

### DIFF
--- a/OPTIMIZATION_REPORT.md
+++ b/OPTIMIZATION_REPORT.md
@@ -1,0 +1,21 @@
+# Performance Optimization Report: Consolidated Component Registration
+
+## 💡 What
+The optimization consolidates multiple calls to `AActor::GetComponents<T>` into a single call to `AActor::GetComponents(TArray<UActorComponent*>& OutComponents)`. It then iterates over the retrieved components once, using `Cast<T>` to identify and register both `UStaticMeshComponent` and `UNiagaraComponent` for optimization tracking.
+
+## 🎯 Why
+Prior to this change, `UAutoOptimizationComponent::RegisterWithOptimizationSystem` would traverse the actor's component list twice: once to find all static meshes and again to find all particle systems. In actors with many components, this leads to redundant CPU cycles and multiple temporary array allocations.
+
+## 🛠️ Implementation Strategy
+- Replaced separate `GetComponents<UStaticMeshComponent>` and `GetComponents<UNiagaraComponent>` calls.
+- Introduced a single pass loop over all components.
+- Used safe casting to identify target component types.
+- Maintained existing registration logic for both component types.
+
+## 📊 Measured Improvement (Theoretical)
+While a live profiling session was not possible in the current headless environment, the theoretical benefits include:
+- **Reduced Time Complexity:** $O(2N)$ reduced to $O(N)$, where $N$ is the number of components on the actor.
+- **Reduced Memory Overhead:** One `TArray` allocation instead of two.
+- **Improved Cache Locality:** Single traversal of the component list is more cache-friendly.
+
+These improvements are particularly valuable during level loading or when spawning many procedurally generated actors with `UAutoOptimizationComponent` enabled.

--- a/Source/BikeAdventure/Systems/PerformanceOptimizationSystem.cpp
+++ b/Source/BikeAdventure/Systems/PerformanceOptimizationSystem.cpp
@@ -761,20 +761,19 @@ void UAutoOptimizationComponent::RegisterWithOptimizationSystem()
         return;
     }
     
-    // Register all static mesh components
-    TArray<UStaticMeshComponent*> MeshComponents;
-    Owner->GetComponents<UStaticMeshComponent>(MeshComponents);
-    for (UStaticMeshComponent* MeshComp : MeshComponents)
+    // Register all relevant components in a single pass
+    TArray<UActorComponent*> Components;
+    Owner->GetComponents(Components);
+    for (UActorComponent* Component : Components)
     {
-        OptimizationSystem->RegisterComponentForOptimization(MeshComp);
-    }
-    
-    // Register all particle systems
-    TArray<UNiagaraComponent*> ParticleComponents;
-    Owner->GetComponents<UNiagaraComponent>(ParticleComponents);
-    for (UNiagaraComponent* ParticleComp : ParticleComponents)
-    {
-        OptimizationSystem->RegisterParticleSystemForOptimization(ParticleComp);
+        if (UStaticMeshComponent* MeshComp = Cast<UStaticMeshComponent>(Component))
+        {
+            OptimizationSystem->RegisterComponentForOptimization(MeshComp);
+        }
+        else if (UNiagaraComponent* ParticleComp = Cast<UNiagaraComponent>(Component))
+        {
+            OptimizationSystem->RegisterParticleSystemForOptimization(ParticleComp);
+        }
     }
     
     // Register PCG actor if this is one


### PR DESCRIPTION
💡 **What:** Consolidate multiple `GetComponents<T>` calls into a single `GetComponents` call followed by a single-pass loop with type casting.

🎯 **Why:** The previous implementation in `UAutoOptimizationComponent::RegisterWithOptimizationSystem` traversed the actor's component list twice, leading to redundant work and multiple temporary array allocations. This is inefficient, especially for complex actors with many components.

📊 **Measured Improvement:** A live performance baseline could not be established due to environment constraints. However, this change is a net performance improvement as it reduces the complexity of component registration from $O(2N)$ to $O(N)$. This leads to fewer CPU cycles and reduced memory overhead per registered actor.

---
*PR created automatically by Jules for task [7154695043523718933](https://jules.google.com/task/7154695043523718933) started by @zvirb*